### PR TITLE
Refactor image writing, add BMP encoder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,10 @@ before_script:
 script:
   # Check code style
   - php vendor/bin/phpcs --standard=psr2 src/ -n
+  # Unit tests
   - php vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  # Example scripts must work too
+  - mkdir -p tmp && (cd tmp && find ../example -name '*.php' -print0 | xargs -n 1 -0 sh -c 'echo $0; php $0 || exit 255')
 
 after_success:
   # Upload coverage statistics to coveralls service after test

--- a/example/font-placeholders.php
+++ b/example/font-placeholders.php
@@ -13,12 +13,12 @@ $charHeight = 7;
 // Create small image for each character
 $chars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"];
 $subImages = [];
-for($i = 0; $i < count($codePoint); $i++) {
-  $id = array_search($codePoint[$i], $chars);
-  if($id === false) {
-    throw new Exception("Don't know how to encode " . $codePoint[$i]);
-  }
-  $subImages[] = $font -> subImage($id * $charWidth, 0, $charWidth, $charHeight);
+for ($i = 0; $i < count($codePoint); $i++) {
+    $id = array_search($codePoint[$i], $chars);
+    if ($id === false) {
+        throw new Exception("Don't know how to encode " . $codePoint[$i]);
+    }
+    $subImages[] = $font -> subImage($id * $charWidth, 0, $charWidth, $charHeight);
 }
 
 // Place four images in a box

--- a/example/format-convert.php
+++ b/example/format-convert.php
@@ -5,28 +5,21 @@ use Mike42\ImagePhp\Image;
 
 // Write colorwheel.ppm out as each supported format
 $img = Image::fromFile(dirname(__FILE__). "/resources/colorwheel.ppm");
-$img2 = $img -> toRgb();
-$img2 -> write("colorwheel-original.pbm");
-$img3 = $img -> toGrayscale();
-$img3 -> write("colorwheel-gray.pgm");
-$img4 = $img -> toBlackAndWhite();
-$img4 -> write("colorwheel-black.pbm");
+$img -> write("colorwheel.bmp");
+$img -> write("colorwheel.pbm");
+$img -> write("colorwheel.pgm");
+$img -> write("colorwheel.ppm");
 
 // Write gradient.pgm out as each supported format
 $img = Image::fromFile(dirname(__FILE__). "/resources/gradient.pgm");
-$img2 = $img -> toGrayscale();
-$img2 -> write("gradient-original.pgm");
-$img3 = $img -> toRgb();
-$img3 -> write("gradient-color.ppm");
-$img4 = $img -> toBlackAndWhite();
-$img4 -> write("gradient-black.pbm");
+$img -> write("gradient.bmp");
+$img -> write("gradient.pbm");
+$img -> write("gradient.pgm");
+$img -> write("gradient.ppm");
 
 // Write 5x7hex.pbm out as each supported format
 $img = Image::fromFile(dirname(__FILE__). "/resources/5x7hex.pbm");
-$img2 = $img -> toBlackAndWhite();
-$img2 -> write("font-original.pbm");
-$img3 = $img -> toRgb();
-$img3 -> write("font-color.ppm");
-$img4 = $img -> toBlackAndWhite();
-$img4 -> write("font-grayscale.pgm");
-
+$img -> write("font.bmp");
+$img -> write("font.pbm");
+$img -> write("font.pgm");
+$img -> write("font.ppm");

--- a/example/pbm-scale.php
+++ b/example/pbm-scale.php
@@ -15,4 +15,3 @@ $img2 -> write("font-small.pbm");
 $img = Image::fromFile(dirname(__FILE__). "/resources/5x7hex.pbm");
 $img3 = $img -> scale(160, 14);
 $img3 -> write("font-large.pbm");
-

--- a/example/pgm-scale.php
+++ b/example/pgm-scale.php
@@ -15,4 +15,3 @@ $img2 -> write("gradient-small.pgm");
 $img = Image::fromFile(dirname(__FILE__). "/resources/gradient.pgm");
 $img3 = $img -> scale(60, 60);
 $img3 -> write("gradient-large.pgm");
-

--- a/example/ppm-scale.php
+++ b/example/ppm-scale.php
@@ -15,4 +15,3 @@ $img2 -> write("colorwheel-small.ppm");
 $img = Image::fromFile(dirname(__FILE__). "/resources/colorwheel.ppm");
 $img3 = $img -> scale(60, 60);
 $img3 -> write("colorwheel-large.ppm");
-

--- a/src/Mike42/ImagePhp/AbstractRasterImage.php
+++ b/src/Mike42/ImagePhp/AbstractRasterImage.php
@@ -2,6 +2,7 @@
 
 namespace Mike42\ImagePhp;
 
+use Mike42\ImagePhp\Codec\ImageCodec;
 use Mike42\ImagePhp\Codec\PnmCodec;
 
 abstract class AbstractRasterImage implements RasterImage
@@ -38,8 +39,13 @@ abstract class AbstractRasterImage implements RasterImage
     
     public function write(string $filename)
     {
-        // Temporary function while we don't support many formats...
-        $blob = PnmCodec::getInstance() -> encode($this);
+        // Use file extension to decide output codec
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        if ($ext === null) {
+            throw new \Exception("Cannot write '$filename': No file extension.");
+        }
+        $encoder = ImageCodec::getInstance() -> getEncoderForFormat($ext);
+        $blob = $encoder -> encode($this, $ext);
         file_put_contents($filename, $blob);
     }
     
@@ -61,7 +67,7 @@ abstract class AbstractRasterImage implements RasterImage
         return $img;
     }
 
-    public function subImage(int $startX, int $startY, int $width, int $height)
+    public function subImage(int $startX, int $startY, int $width, int $height) : RasterImage
     {
         $ret = $this::create($width, $height);
         $ret -> compose($this, $startX, $startY, 0, 0, $width, $height);

--- a/src/Mike42/ImagePhp/BlackAndWhiteRasterImage.php
+++ b/src/Mike42/ImagePhp/BlackAndWhiteRasterImage.php
@@ -151,7 +151,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
         for ($y = 0; $y < $this -> height; $y++) {
             for ($x = 0; $x < $this -> width; $x++) {
                 $original = $this -> getPixel($x, $y);
-                $img -> setPixel($x, $y, $original == 0 ? 0 : 255);
+                $img -> setPixel($x, $y, $original == 0 ? 255 : 0);
             }
         }
         return $img;

--- a/src/Mike42/ImagePhp/BlackAndWhiteRasterImage.php
+++ b/src/Mike42/ImagePhp/BlackAndWhiteRasterImage.php
@@ -46,7 +46,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
     }
 
 
-    public function setPixel(int $x, int $y, $value)
+    public function setPixel(int $x, int $y, int $value)
     {
         if ($x < 0 || $x >= $this -> width) {
             return;

--- a/src/Mike42/ImagePhp/Codec/BmpCodec.php
+++ b/src/Mike42/ImagePhp/Codec/BmpCodec.php
@@ -16,14 +16,17 @@ class BmpCodec implements ImageEncoder
             $image = $image -> toRgb();
         }
         // Output uncompressed 24 bit BMP file
-        $header = pack("nV3",
+        $header = pack(
+            "nV3",
             0x424d, // 'BM' magic number
             0, // File size
             0, // Reserved
-            0); // Offset
+            0
+        ); // Offset
         $width = $image -> getWidth();
         $height = $image -> getHeight();
-        $infoHeader = pack("V3v2V6",
+        $infoHeader = pack(
+            "V3v2V6",
             40,
             $width, // Width
             $height, // Height
@@ -34,7 +37,8 @@ class BmpCodec implements ImageEncoder
             1, // Horizontal res
             1, // Vertical res
             0, // Number of colors
-            0); // Number of important colors
+            0
+        ); // Number of important colors
         $colorTable = "";
         // Transform RGB ordering to BGR ordering
         $pixels = str_split($image -> getRasterData(), 3);

--- a/src/Mike42/ImagePhp/Codec/BmpCodec.php
+++ b/src/Mike42/ImagePhp/Codec/BmpCodec.php
@@ -42,7 +42,7 @@ class BmpCodec implements ImageEncoder
         $colorTable = "";
         // Transform RGB ordering to BGR ordering
         $pixels = str_split($image -> getRasterData(), 3);
-        array_walk($pixels, [$this, "transform_rev_str"]);
+        array_walk($pixels, [$this, "transformRevString"]);
         $rasterData = implode("", $pixels);
         // Transform top-down unpadded lines to bottom-up padded lines
         $originalWidth = $width * 3;
@@ -55,7 +55,7 @@ class BmpCodec implements ImageEncoder
         return $header . $infoHeader . $colorTable . $pixelData;
     }
 
-    function transform_rev_str(&$item, $key)
+    protected function transformRevString(&$item, $key)
     {
         $item = strrev($item);
     }

--- a/src/Mike42/ImagePhp/Codec/BmpCodec.php
+++ b/src/Mike42/ImagePhp/Codec/BmpCodec.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Mike42\ImagePhp\Codec;
+
+use Mike42\ImagePhp\RasterImage;
+use Mike42\ImagePhp\RgbRasterImage;
+
+class BmpCodec implements ImageEncoder
+{
+    protected static $instance = null;
+
+    public function encode(RasterImage $image, string $format): string
+    {
+        if (!($image instanceof RgbRasterImage)) {
+            // Convert if necessary
+            $image = $image -> toRgb();
+        }
+        // Output uncompressed 24 bit BMP file
+        $header = pack("nV3",
+            0x424d, // 'BM' magic number
+            0, // File size
+            0, // Reserved
+            0); // Offset
+        $width = $image -> getWidth();
+        $height = $image -> getHeight();
+        $infoHeader = pack("V3v2V6",
+            40,
+            $width, // Width
+            $height, // Height
+            1, // Planes
+            24, // bpp
+            0, // Compression (none)
+            0, // Image size compressed
+            1, // Horizontal res
+            1, // Vertical res
+            0, // Number of colors
+            0); // Number of important colors
+        $colorTable = "";
+        // Transform RGB ordering to BGR ordering
+        $pixels = str_split($image -> getRasterData(), 3);
+        array_walk($pixels, [$this, "transform_rev_str"]);
+        $rasterData = implode("", $pixels);
+        // Transform top-down unpadded lines to bottom-up padded lines
+        $originalWidth = $width * 3;
+        $paddingLength = (4 - ($originalWidth & 3)) & 3;
+        $padding = str_repeat("\x00", $paddingLength);
+        $lines = str_split($rasterData, $originalWidth);
+        $lines = array_reverse($lines, false);
+        $pixelData = implode($padding, $lines) . $padding;
+        // Return bitmap & header
+        return $header . $infoHeader . $colorTable . $pixelData;
+    }
+
+    function transform_rev_str(&$item, $key)
+    {
+        $item = strrev($item);
+    }
+    
+    public function getEncodeFormats(): array
+    {
+        return ["bmp", "dib"];
+    }
+
+    public static function getInstance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new BmpCodec();
+        }
+        return self::$instance;
+    }
+}

--- a/src/Mike42/ImagePhp/Codec/ImageCodec.php
+++ b/src/Mike42/ImagePhp/Codec/ImageCodec.php
@@ -4,34 +4,56 @@ namespace Mike42\ImagePhp\Codec;
 class ImageCodec
 {
     protected static $instance = null;
-    
+
     protected $encoders;
-    
+
     protected $decoders;
-    
+
     public function __construct(array $encoders, array $decoders)
     {
         $this -> encoders = $encoders;
         $this -> decoders = $decoders;
     }
-    
+
     public function identify(string $blob) : string
     {
-        // TODO
-        return "image/x‑portable‑bitmap";
-    }
-    
-    public function getDecoderForFormat(string $format) : ImageDecoder
-    {
-        // TODO
-        return $this -> encoders[0];
+        foreach ($this -> decoders as $decoder) {
+            $identity = $decoder -> identify($blob);
+            if ($identity !== null) {
+                return $identity;
+            }
+        }
+        return null;
     }
 
+    public function getDecoderForFormat(string $format) : ImageDecoder
+    {
+        $format = strtolower($format);
+        foreach ($this -> decoders as $decoder) {
+            if (array_search($format, $decoder -> getDecodeFormats(), true) !== false) {
+                return $decoder;
+            }
+        }
+        throw new \Exception("No decoder for format $format");
+    }
+
+    public function getEncoderForFormat(string $format) : ImageEncoder
+    {
+        $format = strtolower($format);
+        foreach ($this -> encoders as $encoder) {
+            if (array_search($format, $encoder -> getEncodeFormats(), true) !== false) {
+                return $encoder;
+            }
+        }
+        throw new \Exception("No encoder for format $format");
+    }
+    
     public static function getInstance() : ImageCodec
     {
         if (self::$instance  === null) {
             $encoders = [
-                PnmCodec::getInstance()
+                PnmCodec::getInstance(),
+                BmpCodec::getInstance()
             ];
             $decoders = [
                 PnmCodec::getInstance()

--- a/src/Mike42/ImagePhp/Codec/ImageEncoder.php
+++ b/src/Mike42/ImagePhp/Codec/ImageEncoder.php
@@ -7,5 +7,5 @@ interface ImageEncoder
 {
     public function getEncodeFormats() : array;
 
-    public function encode(RasterImage $image) : string;
+    public function encode(RasterImage $image, string $format) : string;
 }

--- a/src/Mike42/ImagePhp/GrayscaleRasterImage.php
+++ b/src/Mike42/ImagePhp/GrayscaleRasterImage.php
@@ -21,7 +21,7 @@ class GrayscaleRasterImage extends AbstractRasterImage
         return $this -> height;
     }
 
-    public function setPixel(int $x, int $y, $value)
+    public function setPixel(int $x, int $y, int $value)
     {
         if ($x < 0 || $x >= $this -> width) {
             return;

--- a/src/Mike42/ImagePhp/RasterImage.php
+++ b/src/Mike42/ImagePhp/RasterImage.php
@@ -13,4 +13,14 @@ interface RasterImage
     public function scale(int $width, int $height): RasterImage;
     
     public function write(string $filename);
+    
+    public function toRgb() : RgbRasterImage;
+    
+    public function getPixel(int $x, int $y);
+    
+    public function setPixel(int $x, int $y, int $value);
+    
+    public function toGrayscale();
+    
+    public function toBlackAndWhite();
 }

--- a/src/Mike42/ImagePhp/RgbRasterImage.php
+++ b/src/Mike42/ImagePhp/RgbRasterImage.php
@@ -60,7 +60,7 @@ class RgbRasterImage extends AbstractRasterImage
         ];
     }
 
-    public function setPixel(int $x, int $y, $value)
+    public function setPixel(int $x, int $y, int $value)
     {
         if ($x < 0 || $x >= $this -> width) {
             return;


### PR DESCRIPTION
The library now auto-selects the output format based on the file extension, and implements an encoder, which will write 24 bit-per-pixel BMP files when `.bmp` is used.

Ref:

- #8 
- #6