### PR TITLE
Add PNG encoder

### DIFF
--- a/example/format-convert.php
+++ b/example/format-convert.php
@@ -8,6 +8,7 @@ $img = Image::fromFile(dirname(__FILE__). "/resources/colorwheel.ppm");
 $img -> write("colorwheel.bmp");
 $img -> write("colorwheel.pbm");
 $img -> write("colorwheel.pgm");
+$img -> write("colorwheel.png");
 $img -> write("colorwheel.ppm");
 
 // Write gradient.pgm out as each supported format
@@ -15,6 +16,7 @@ $img = Image::fromFile(dirname(__FILE__). "/resources/gradient.pgm");
 $img -> write("gradient.bmp");
 $img -> write("gradient.pbm");
 $img -> write("gradient.pgm");
+$img -> write("gradient.png");
 $img -> write("gradient.ppm");
 
 // Write 5x7hex.pbm out as each supported format
@@ -22,4 +24,5 @@ $img = Image::fromFile(dirname(__FILE__). "/resources/5x7hex.pbm");
 $img -> write("font.bmp");
 $img -> write("font.pbm");
 $img -> write("font.pgm");
+$img -> write("font.png");
 $img -> write("font.ppm");

--- a/src/Mike42/ImagePhp/AbstractRasterImage.php
+++ b/src/Mike42/ImagePhp/AbstractRasterImage.php
@@ -58,7 +58,6 @@ abstract class AbstractRasterImage implements RasterImage
             for ($x = 0; $x < $width; $x++) {
                 $srcX = intdiv($x * $thisWidth, $width);
                 $srcY = intdiv($y * $thisHeight, $height);
-                //echo "$srcX / $thisWidth ->  $x / $width \n";
                 $srcColor = $this -> getPixel($srcX, $srcY);
                 $destColor = $this -> mapColor($srcColor, $img);
                 $img -> setPixel($x, $y, $destColor);

--- a/src/Mike42/ImagePhp/Codec/BmpCodec.php
+++ b/src/Mike42/ImagePhp/Codec/BmpCodec.php
@@ -17,8 +17,9 @@ class BmpCodec implements ImageEncoder
         }
         // Output uncompressed 24 bit BMP file
         $header = pack(
-            "nV3",
-            0x424d, // 'BM' magic number
+            "C2V3",
+            0x42,
+            0x4d, // 'BM' magic number
             0, // File size
             0, // Reserved
             0

--- a/src/Mike42/ImagePhp/Codec/ImageCodec.php
+++ b/src/Mike42/ImagePhp/Codec/ImageCodec.php
@@ -45,7 +45,7 @@ class ImageCodec
                 return $encoder;
             }
         }
-        throw new \Exception("No encoder for format $format");
+        throw new \Exception("No encoder for format '$format'");
     }
     
     public static function getInstance() : ImageCodec
@@ -53,7 +53,8 @@ class ImageCodec
         if (self::$instance  === null) {
             $encoders = [
                 PnmCodec::getInstance(),
-                BmpCodec::getInstance()
+                BmpCodec::getInstance(),
+                PngCodec::getInstance()
             ];
             $decoders = [
                 PnmCodec::getInstance()

--- a/src/Mike42/ImagePhp/Codec/PngCodec.php
+++ b/src/Mike42/ImagePhp/Codec/PngCodec.php
@@ -1,0 +1,58 @@
+<?php
+namespace Mike42\ImagePhp\Codec;
+
+use Mike42\ImagePhp\RasterImage;
+use Mike42\ImagePhp\RgbRasterImage;
+
+class PngCodec implements ImageEncoder
+{
+    protected static $instance = null;
+
+    public function encode(RasterImage $image, string $format): string
+    {
+        if (!($image instanceof RgbRasterImage)) {
+            // Convert if necessary
+            $image = $image -> toRgb();
+        }
+        return $this -> encodeRgb($image);
+    }
+
+    public function encodeRgb(RgbRasterImage $image)
+    {
+        // PNG signature
+        $signature = pack("c8", 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
+        // Header chunk
+        $width = $image -> getWidth();
+        $height = $image -> getHeight();
+        $ihdr = $this -> chunk('IHDR', pack('N2C5', $width, $height, 8, 2, 0, 0, 0));
+        // Prepend '0' filter method to each scanline
+        $scanLines = str_split($image -> getRasterData(), $width * 3);
+        $pngRasterData = chr(0) . implode(chr(0), $scanLines);
+        $idat = $this -> chunk('IDAT', zlib_encode($pngRasterData, ZLIB_ENCODING_DEFLATE));
+        // End chunk
+        $iend = $this -> chunk('IEND');
+        return $signature . $ihdr . $idat . $iend;
+    }
+
+    protected function chunk(string $type, string $data = '')
+    {
+        $len = strlen($data);
+        $lenData = pack("N", $len);
+        $bodyData = $type . $data;
+        $crcData = pack("N", crc32($bodyData));
+        return $lenData . $bodyData . $crcData;
+    }
+
+    public function getEncodeFormats(): array
+    {
+        return ["png"];
+    }
+
+    public static function getInstance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new PngCodec();
+        }
+        return self::$instance;
+    }
+}


### PR DESCRIPTION
Images can now be saved as PNG. They are converted to a 24 bit-per-pixel RGB image, and saved as non-interlaced and non-filtered.

```
$img = Image::fromFile(dirname(__FILE__). "/resources/colorwheel.ppm");
$img -> write("colorwheel.png");
```

Ref:

- #10
