### PR TITLE
API documentation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 vendor
 build
+docs/_build/
+docs/warnings.log
+docs/xml/
+docs/html/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,4 +7,4 @@ API documentation
    api/*
 
 
-    
+

--- a/docs/api/abstractrasterimage.rst
+++ b/docs/api/abstractrasterimage.rst
@@ -3,7 +3,7 @@ AbstractRasterImage
 
 .. php:class:: AbstractRasterImage
 
-  .. php:method:: rect ($startX, $startY, $width, $height, $filled=false, $outline=1, $fill=1)
+  .. php:method:: rect ($startX, $startY, $width, $height, $filled, $outline, $fill)
 
     Produce a rectangle with the given properties.
 
@@ -44,7 +44,7 @@ AbstractRasterImage
 
   .. php:method:: compose (RasterImage $source, int $startX, int $startY, int $destStartX, int $destStartY, int $width, int $height)
 
-    :param $source:
+    :param :class:`RasterImage` $source:
     :param int $startX:
     :param int $startY:
     :param int $destStartX:

--- a/docs/api/abstractrasterimage.rst
+++ b/docs/api/abstractrasterimage.rst
@@ -3,7 +3,7 @@ AbstractRasterImage
 
 .. php:class:: AbstractRasterImage
 
-  .. php:method:: rect ($startX, $startY, $width, $height, $filled, $outline, $fill)
+  .. php:method:: rect ($startX, $startY, $width, $height[, $filled, $outline, $fill])
 
     Produce a rectangle with the given properties.
 
@@ -25,7 +25,7 @@ AbstractRasterImage
     :param string $filename:
       Filename to write to.
 
-  .. php:method:: scale (int $width, int $height)
+  .. php:method:: scale (int $width, int $height) -> RasterImage
 
     Produce a new :class:`RasterImage` based on this one. The new image will be scaled to the requested dimensions via resampling.
 
@@ -33,7 +33,7 @@ AbstractRasterImage
       The width of the returned image.
     :param int $height:
       The height of the returned image.
-    :returns: :class:`RasterImage` A scaled version of the image.
+    :returns: :class:`RasterImage` -- A scaled version of the image.
 
   .. php:method:: subImage (int $startX, int $startY, int $width, int $height)
 
@@ -44,7 +44,7 @@ AbstractRasterImage
 
   .. php:method:: compose (RasterImage $source, int $startX, int $startY, int $destStartX, int $destStartY, int $width, int $height)
 
-    :param :class:`RasterImage` $source:
+    :param RasterImage $source:
     :param int $startX:
     :param int $startY:
     :param int $destStartX:

--- a/docs/api/abstractrasterimage.rst
+++ b/docs/api/abstractrasterimage.rst
@@ -7,13 +7,18 @@ AbstractRasterImage
 
   .. php:method:: write (string $filename)
 
-      :param string $filename: Filename to write to.
+    Write the image to a file. The output format is determined by the file extension.
+
+    :param string $filename: Filename to write to.
 
   .. php:method:: scale (int $width, int $height)
 
-      :param int $width: The width of the returned image.
-      :param int $height: The height of the returned image.
-      :returns: :class:`RasterImage`
+    Produce a new :class:`RasterImage` based on this one. The new image will be scaled to the requested dimensions via resampling.
+
+    :param int $width: The width of the returned image.
+    :param int $height: The height of the returned image.
+    :returns: :class:`RasterImage` A scaled version of the image.
+
   .. php:method:: subImage (int $startX, int $startY, int $width, int $height)
 
   .. php:method:: compose (RasterImage $source, int $startX, int $startY, int $destStartX, int $destStartY, int $width, int $height)

--- a/docs/api/abstractrasterimage.rst
+++ b/docs/api/abstractrasterimage.rst
@@ -14,7 +14,6 @@ AbstractRasterImage
       :param int $width: The width of the returned image.
       :param int $height: The height of the returned image.
       :returns: :class:`RasterImage`
-
   .. php:method:: subImage (int $startX, int $startY, int $width, int $height)
 
   .. php:method:: compose (RasterImage $source, int $startX, int $startY, int $destStartX, int $destStartY, int $width, int $height)

--- a/docs/api/abstractrasterimage.rst
+++ b/docs/api/abstractrasterimage.rst
@@ -5,6 +5,14 @@ AbstractRasterImage
 
   .. php:method:: rect ($startX, $startY, $width, $height, $filled=false, $outline=1, $fill=1)
 
+    :param $startX:
+    :param $startY:
+    :param $width:
+    :param $height:
+    :param $filled:
+    :param $outline:
+    :param $fill:
+
   .. php:method:: write (string $filename)
 
     Write the image to a file. The output format is determined by the file extension.
@@ -21,5 +29,18 @@ AbstractRasterImage
 
   .. php:method:: subImage (int $startX, int $startY, int $width, int $height)
 
+    :param int $startX:
+    :param int $startY:
+    :param int $width:
+    :param int $height:
+
   .. php:method:: compose (RasterImage $source, int $startX, int $startY, int $destStartX, int $destStartY, int $width, int $height)
+
+    :param $source:
+    :param int $startX:
+    :param int $startY:
+    :param int $destStartX:
+    :param int $destStartY:
+    :param int $width:
+    :param int $height:
 

--- a/docs/api/abstractrasterimage.rst
+++ b/docs/api/abstractrasterimage.rst
@@ -7,7 +7,13 @@ AbstractRasterImage
 
   .. php:method:: write (string $filename)
 
+      :param string $filename: Filename to write to.
+
   .. php:method:: scale (int $width, int $height)
+
+      :param int $width: The width of the returned image.
+      :param int $height: The height of the returned image.
+      :returns: :class:`RasterImage`
 
   .. php:method:: subImage (int $startX, int $startY, int $width, int $height)
 

--- a/docs/api/abstractrasterimage.rst
+++ b/docs/api/abstractrasterimage.rst
@@ -5,26 +5,34 @@ AbstractRasterImage
 
   .. php:method:: rect ($startX, $startY, $width, $height, $filled=false, $outline=1, $fill=1)
 
+    Produce a rectangle with the given properties.
+
     :param $startX:
     :param $startY:
     :param $width:
     :param $height:
     :param $filled:
+      Default: ``false``
     :param $outline:
-    :param $fill:
+      Default: ``1``
+    :param int $fill:
+      Default: ``1``
 
   .. php:method:: write (string $filename)
 
     Write the image to a file. The output format is determined by the file extension.
 
-    :param string $filename: Filename to write to.
+    :param string $filename:
+      Filename to write to.
 
   .. php:method:: scale (int $width, int $height)
 
     Produce a new :class:`RasterImage` based on this one. The new image will be scaled to the requested dimensions via resampling.
 
-    :param int $width: The width of the returned image.
-    :param int $height: The height of the returned image.
+    :param int $width:
+      The width of the returned image.
+    :param int $height:
+      The height of the returned image.
     :returns: :class:`RasterImage` A scaled version of the image.
 
   .. php:method:: subImage (int $startX, int $startY, int $width, int $height)

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -10,11 +10,9 @@ BlackAndWhiteRasterImage
   .. php:method:: getWidth ()
 
       :returns: int
-
   .. php:method:: getHeight ()
 
       :returns: int
-
   .. php:method:: setPixel (int $x, int $y, int $value)
 
       :param int $x: X co-ordinate
@@ -26,28 +24,23 @@ BlackAndWhiteRasterImage
       :param int $x: X co-ordinate
       :param int $y: Y co-ordinate
       :returns: int
-
   .. php:method:: toString ()
 
   .. php:method:: getRasterData ()
 
       :returns: string
-
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
       :returns: :class:`RgbRasterImage`
-
   .. php:method:: toGrayscale ()
 
       :returns: :class:`GrayscaleRasterImage`
-
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
 
       :returns: :class:`IndexedRasterImage`
-
   .. php:staticmethod:: create ($width, $height, array $data=null)
 

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -27,16 +27,21 @@ Small implementation of basic raster operations on PBM files to support creation
 
     Set the value of a given pixel.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
-    :param int $value: Value to set
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
+    :param int $value:
+      Value to set
 
   .. php:method:: getPixel (int $x, int $y)
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
     :returns: int The value of the pixel at ($x, $y).
 
   .. php:method:: toString ()
@@ -82,4 +87,5 @@ Small implementation of basic raster operations on PBM files to support creation
     :param $width:
     :param $height:
     :param array $data:
+      Default: ``null``
 

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -3,44 +3,73 @@ BlackAndWhiteRasterImage
 
 .. php:class:: BlackAndWhiteRasterImage
 
+  Small implementation of basic raster operations on PBM files to support creation of placeholder glyphs
+
   .. php:method:: invert ()
 
   .. php:method:: clear ()
 
   .. php:method:: getWidth ()
 
-      :returns: int
+    Get the width of the image in pixels.
+
+    :returns: int The width of the image in pixels.
+
   .. php:method:: getHeight ()
 
-      :returns: int
+    Get the height of the image in pixels.
+
+    :returns: int The height of the image in pixels.
+
   .. php:method:: setPixel (int $x, int $y, int $value)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :param int $value: Value to set
+    Set the value of a given pixel.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :param int $value: Value to set
 
   .. php:method:: getPixel (int $x, int $y)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :returns: int
+    Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :returns: int The value of the pixel at ($x, $y).
+
   .. php:method:: toString ()
 
   .. php:method:: getRasterData ()
 
-      :returns: string
+    Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
+
+    :returns: string A binary string representation of the raster data for this image.
+
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
-      :returns: :class:`RgbRasterImage`
+    Produce a copy of this :class:`RasterImage` in the RGB colorspace.
+
+    :returns: :class:`RgbRasterImage` An RGB version of the image.
+
   .. php:method:: toGrayscale ()
 
-      :returns: :class:`GrayscaleRasterImage`
+    Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
+
+    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+
   .. php:method:: toBlackAndWhite ()
+
+    Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
+
+    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
 
   .. php:method:: toIndexed ()
 
-      :returns: :class:`IndexedRasterImage`
+    Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
+
+    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+
   .. php:staticmethod:: create ($width, $height, array $data=null)
 

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -1,13 +1,15 @@
 BlackAndWhiteRasterImage
 ========================
 
-.. php:class:: BlackAndWhiteRasterImage
+Small implementation of basic raster operations on PBM files to support creation of placeholder glyphs
 
-  Small implementation of basic raster operations on PBM files to support creation of placeholder glyphs
+.. php:class:: BlackAndWhiteRasterImage
 
   .. php:method:: invert ()
 
+
   .. php:method:: clear ()
+
 
   .. php:method:: getWidth ()
 
@@ -39,6 +41,7 @@ BlackAndWhiteRasterImage
 
   .. php:method:: toString ()
 
+
   .. php:method:: getRasterData ()
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
@@ -46,6 +49,9 @@ BlackAndWhiteRasterImage
     :returns: string A binary string representation of the raster data for this image.
 
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
+
+    :param int $srcColor:
+    :param $destImage:
 
   .. php:method:: toRgb ()
 

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -79,3 +79,7 @@ Small implementation of basic raster operations on PBM files to support creation
 
   .. php:staticmethod:: create ($width, $height, array $data=null)
 
+    :param $width:
+    :param $height:
+    :param array $data:
+

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -11,17 +11,17 @@ Small implementation of basic raster operations on PBM files to support creation
   .. php:method:: clear ()
 
 
-  .. php:method:: getWidth ()
+  .. php:method:: getWidth () -> int
 
     Get the width of the image in pixels.
 
-    :returns: int The width of the image in pixels.
+    :returns: int -- The width of the image in pixels.
 
-  .. php:method:: getHeight ()
+  .. php:method:: getHeight () -> int
 
     Get the height of the image in pixels.
 
-    :returns: int The height of the image in pixels.
+    :returns: int -- The height of the image in pixels.
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
@@ -34,7 +34,7 @@ Small implementation of basic raster operations on PBM files to support creation
     :param int $value:
       Value to set
 
-  .. php:method:: getPixel (int $x, int $y)
+  .. php:method:: getPixel (int $x, int $y) -> int
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
@@ -42,47 +42,47 @@ Small implementation of basic raster operations on PBM files to support creation
       X co-ordinate
     :param int $y:
       Y co-ordinate
-    :returns: int The value of the pixel at ($x, $y).
+    :returns: int -- The value of the pixel at ($x, $y).
 
   .. php:method:: toString ()
 
 
-  .. php:method:: getRasterData ()
+  .. php:method:: getRasterData () -> string
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
 
-    :returns: string A binary string representation of the raster data for this image.
+    :returns: string -- A binary string representation of the raster data for this image.
 
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
     :param int $srcColor:
-    :param :class:`RasterImage` $destImage:
+    :param RasterImage $destImage:
 
-  .. php:method:: toRgb ()
+  .. php:method:: toRgb () -> RgbRasterImage
 
     Produce a copy of this :class:`RasterImage` in the RGB colorspace.
 
-    :returns: :class:`RgbRasterImage` An RGB version of the image.
+    :returns: :class:`RgbRasterImage` -- An RGB version of the image.
 
-  .. php:method:: toGrayscale ()
+  .. php:method:: toGrayscale () -> GrayscaleRasterImage
 
     Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
 
-    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+    :returns: :class:`GrayscaleRasterImage` -- A monochrome version of the image.
 
-  .. php:method:: toBlackAndWhite ()
+  .. php:method:: toBlackAndWhite () -> BlackAndWhiteRasterImage
 
     Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
 
-    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
+    :returns: :class:`BlackAndWhiteRasterImage` -- a black and white version of the image.
 
-  .. php:method:: toIndexed ()
+  .. php:method:: toIndexed () -> IndexedRasterImage
 
     Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
 
-    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+    :returns: :class:`IndexedRasterImage` -- An paletted version of the image.
 
-  .. php:staticmethod:: create ($width, $height, array $data)
+  .. php:staticmethod:: create ($width, $height[, array $data])
 
     :param $width:
     :param $height:

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -9,25 +9,45 @@ BlackAndWhiteRasterImage
 
   .. php:method:: getWidth ()
 
+      :returns: int
+
   .. php:method:: getHeight ()
+
+      :returns: int
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :param int $value: Value to set
+
   .. php:method:: getPixel (int $x, int $y)
+
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :returns: int
 
   .. php:method:: toString ()
 
   .. php:method:: getRasterData ()
 
+      :returns: string
+
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
+      :returns: :class:`RgbRasterImage`
+
   .. php:method:: toGrayscale ()
+
+      :returns: :class:`GrayscaleRasterImage`
 
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
+
+      :returns: :class:`IndexedRasterImage`
 
   .. php:staticmethod:: create ($width, $height, array $data=null)
 

--- a/docs/api/blackandwhiterasterimage.rst
+++ b/docs/api/blackandwhiterasterimage.rst
@@ -56,7 +56,7 @@ Small implementation of basic raster operations on PBM files to support creation
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
     :param int $srcColor:
-    :param $destImage:
+    :param :class:`RasterImage` $destImage:
 
   .. php:method:: toRgb ()
 
@@ -82,7 +82,7 @@ Small implementation of basic raster operations on PBM files to support creation
 
     :returns: :class:`IndexedRasterImage` An paletted version of the image.
 
-  .. php:staticmethod:: create ($width, $height, array $data=null)
+  .. php:staticmethod:: create ($width, $height, array $data)
 
     :param $width:
     :param $height:

--- a/docs/api/codec/bmpcodec.rst
+++ b/docs/api/codec/bmpcodec.rst
@@ -5,7 +5,11 @@ BmpCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
+    :param $image:
+    :param string $format:
+
   .. php:method:: getEncodeFormats ()
+
 
   .. php:staticmethod:: getInstance ()
 

--- a/docs/api/codec/bmpcodec.rst
+++ b/docs/api/codec/bmpcodec.rst
@@ -13,3 +13,4 @@ BmpCodec
 
   .. php:staticmethod:: getInstance ()
 
+

--- a/docs/api/codec/bmpcodec.rst
+++ b/docs/api/codec/bmpcodec.rst
@@ -5,7 +5,7 @@ BmpCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param :class:`RasterImage` $image:
+    :param RasterImage $image:
     :param string $format:
 
   .. php:method:: getEncodeFormats ()

--- a/docs/api/codec/bmpcodec.rst
+++ b/docs/api/codec/bmpcodec.rst
@@ -5,7 +5,7 @@ BmpCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param $image:
+    :param :class:`RasterImage` $image:
     :param string $format:
 
   .. php:method:: getEncodeFormats ()

--- a/docs/api/codec/gifcodec.rst
+++ b/docs/api/codec/gifcodec.rst
@@ -5,7 +5,7 @@ GifCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param :class:`RasterImage` $image:
+    :param RasterImage $image:
     :param string $format:
 
   .. php:method:: getEncodeFormats ()

--- a/docs/api/codec/gifcodec.rst
+++ b/docs/api/codec/gifcodec.rst
@@ -5,7 +5,11 @@ GifCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
+    :param $image:
+    :param string $format:
+
   .. php:method:: getEncodeFormats ()
+
 
   .. php:staticmethod:: getInstance ()
 

--- a/docs/api/codec/gifcodec.rst
+++ b/docs/api/codec/gifcodec.rst
@@ -13,3 +13,4 @@ GifCodec
 
   .. php:staticmethod:: getInstance ()
 
+

--- a/docs/api/codec/gifcodec.rst
+++ b/docs/api/codec/gifcodec.rst
@@ -5,7 +5,7 @@ GifCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param $image:
+    :param :class:`RasterImage` $image:
     :param string $format:
 
   .. php:method:: getEncodeFormats ()

--- a/docs/api/codec/imagecodec.rst
+++ b/docs/api/codec/imagecodec.rst
@@ -5,11 +5,20 @@ ImageCodec
 
   .. php:method:: __construct (array $encoders, array $decoders)
 
+    :param array $encoders:
+    :param array $decoders:
+
   .. php:method:: identify (string $blob)
+
+    :param string $blob:
 
   .. php:method:: getDecoderForFormat (string $format)
 
+    :param string $format:
+
   .. php:method:: getEncoderForFormat (string $format)
+
+    :param string $format:
 
   .. php:staticmethod:: getInstance ()
 

--- a/docs/api/codec/imagecodec.rst
+++ b/docs/api/codec/imagecodec.rst
@@ -22,3 +22,4 @@ ImageCodec
 
   .. php:staticmethod:: getInstance ()
 
+

--- a/docs/api/codec/imagedecoder.rst
+++ b/docs/api/codec/imagedecoder.rst
@@ -1,7 +1,7 @@
 ImageDecoder
 ============
 
-.. php:class:: ImageDecoder
+.. php:interface:: ImageDecoder
 
   .. php:method:: getDecodeFormats ()
 

--- a/docs/api/codec/imagedecoder.rst
+++ b/docs/api/codec/imagedecoder.rst
@@ -5,7 +5,12 @@ ImageDecoder
 
   .. php:method:: getDecodeFormats ()
 
+
   .. php:method:: identify (string $blob)
 
+    :param string $blob:
+
   .. php:method:: decode (string $blob)
+
+    :param string $blob:
 

--- a/docs/api/codec/imageencoder.rst
+++ b/docs/api/codec/imageencoder.rst
@@ -5,5 +5,9 @@ ImageEncoder
 
   .. php:method:: getEncodeFormats ()
 
+
   .. php:method:: encode (RasterImage $image, string $format)
+
+    :param $image:
+    :param string $format:
 

--- a/docs/api/codec/imageencoder.rst
+++ b/docs/api/codec/imageencoder.rst
@@ -8,6 +8,6 @@ ImageEncoder
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param $image:
+    :param :class:`RasterImage` $image:
     :param string $format:
 

--- a/docs/api/codec/imageencoder.rst
+++ b/docs/api/codec/imageencoder.rst
@@ -1,7 +1,7 @@
 ImageEncoder
 ============
 
-.. php:class:: ImageEncoder
+.. php:interface:: ImageEncoder
 
   .. php:method:: getEncodeFormats ()
 

--- a/docs/api/codec/imageencoder.rst
+++ b/docs/api/codec/imageencoder.rst
@@ -8,6 +8,6 @@ ImageEncoder
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param :class:`RasterImage` $image:
+    :param RasterImage $image:
     :param string $format:
 

--- a/docs/api/codec/pngcodec.rst
+++ b/docs/api/codec/pngcodec.rst
@@ -5,12 +5,12 @@ PngCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param $image:
+    :param :class:`RasterImage` $image:
     :param string $format:
 
   .. php:method:: encodeRgb (RgbRasterImage $image)
 
-    :param $image:
+    :param :class:`RgbRasterImage` $image:
 
   .. php:method:: getEncodeFormats ()
 

--- a/docs/api/codec/pngcodec.rst
+++ b/docs/api/codec/pngcodec.rst
@@ -17,3 +17,4 @@ PngCodec
 
   .. php:staticmethod:: getInstance ()
 
+

--- a/docs/api/codec/pngcodec.rst
+++ b/docs/api/codec/pngcodec.rst
@@ -5,9 +5,15 @@ PngCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
+    :param $image:
+    :param string $format:
+
   .. php:method:: encodeRgb (RgbRasterImage $image)
 
+    :param $image:
+
   .. php:method:: getEncodeFormats ()
+
 
   .. php:staticmethod:: getInstance ()
 

--- a/docs/api/codec/pngcodec.rst
+++ b/docs/api/codec/pngcodec.rst
@@ -5,12 +5,12 @@ PngCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param :class:`RasterImage` $image:
+    :param RasterImage $image:
     :param string $format:
 
   .. php:method:: encodeRgb (RgbRasterImage $image)
 
-    :param :class:`RgbRasterImage` $image:
+    :param RgbRasterImage $image:
 
   .. php:method:: getEncodeFormats ()
 

--- a/docs/api/codec/pnmcodec.rst
+++ b/docs/api/codec/pnmcodec.rst
@@ -16,7 +16,7 @@ PnmCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param $image:
+    :param :class:`RasterImage` $image:
     :param string $format:
 
   .. php:method:: getEncodeFormats ()

--- a/docs/api/codec/pnmcodec.rst
+++ b/docs/api/codec/pnmcodec.rst
@@ -24,3 +24,4 @@ PnmCodec
 
   .. php:staticmethod:: getInstance ()
 
+

--- a/docs/api/codec/pnmcodec.rst
+++ b/docs/api/codec/pnmcodec.rst
@@ -5,13 +5,22 @@ PnmCodec
 
   .. php:method:: identify (string $blob)
 
+    :param string $blob:
+
   .. php:method:: decode (string $blob)
+
+    :param string $blob:
 
   .. php:method:: getDecodeFormats ()
 
+
   .. php:method:: encode (RasterImage $image, string $format)
 
+    :param $image:
+    :param string $format:
+
   .. php:method:: getEncodeFormats ()
+
 
   .. php:staticmethod:: getInstance ()
 

--- a/docs/api/codec/pnmcodec.rst
+++ b/docs/api/codec/pnmcodec.rst
@@ -16,7 +16,7 @@ PnmCodec
 
   .. php:method:: encode (RasterImage $image, string $format)
 
-    :param :class:`RasterImage` $image:
+    :param RasterImage $image:
     :param string $format:
 
   .. php:method:: getEncodeFormats ()

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -19,16 +19,21 @@ GrayscaleRasterImage
 
     Set the value of a given pixel.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
-    :param int $value: Value to set
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
+    :param int $value:
+      Value to set
 
   .. php:method:: getPixel (int $x, int $y)
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
     :returns: int The value of the pixel at ($x, $y).
 
   .. php:method:: getMaxVal ()
@@ -74,5 +79,7 @@ GrayscaleRasterImage
     :param $width:
     :param $height:
     :param array $data:
+      Default: ``null``
     :param $maxVal:
+      Default: ``255``
 

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -33,6 +33,7 @@ GrayscaleRasterImage
 
   .. php:method:: getMaxVal ()
 
+
   .. php:method:: getRasterData ()
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
@@ -40,6 +41,9 @@ GrayscaleRasterImage
     :returns: string A binary string representation of the raster data for this image.
 
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
+
+    :param int $srcColor:
+    :param $destImage:
 
   .. php:method:: toRgb ()
 

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -5,25 +5,45 @@ GrayscaleRasterImage
 
   .. php:method:: getWidth ()
 
+      :returns: int
+
   .. php:method:: getHeight ()
+
+      :returns: int
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :param int $value: Value to set
+
   .. php:method:: getPixel (int $x, int $y)
+
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :returns: int
 
   .. php:method:: getMaxVal ()
 
   .. php:method:: getRasterData ()
 
+      :returns: string
+
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
+      :returns: :class:`RgbRasterImage`
+
   .. php:method:: toGrayscale ()
+
+      :returns: :class:`GrayscaleRasterImage`
 
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
+
+      :returns: :class:`IndexedRasterImage`
 
   .. php:staticmethod:: create ($width, $height, array $data=null, $maxVal=255)
 

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -71,3 +71,8 @@ GrayscaleRasterImage
 
   .. php:staticmethod:: create ($width, $height, array $data=null, $maxVal=255)
 
+    :param $width:
+    :param $height:
+    :param array $data:
+    :param $maxVal:
+

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -5,38 +5,65 @@ GrayscaleRasterImage
 
   .. php:method:: getWidth ()
 
-      :returns: int
+    Get the width of the image in pixels.
+
+    :returns: int The width of the image in pixels.
+
   .. php:method:: getHeight ()
 
-      :returns: int
+    Get the height of the image in pixels.
+
+    :returns: int The height of the image in pixels.
+
   .. php:method:: setPixel (int $x, int $y, int $value)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :param int $value: Value to set
+    Set the value of a given pixel.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :param int $value: Value to set
 
   .. php:method:: getPixel (int $x, int $y)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :returns: int
+    Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :returns: int The value of the pixel at ($x, $y).
+
   .. php:method:: getMaxVal ()
 
   .. php:method:: getRasterData ()
 
-      :returns: string
+    Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
+
+    :returns: string A binary string representation of the raster data for this image.
+
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
-      :returns: :class:`RgbRasterImage`
+    Produce a copy of this :class:`RasterImage` in the RGB colorspace.
+
+    :returns: :class:`RgbRasterImage` An RGB version of the image.
+
   .. php:method:: toGrayscale ()
 
-      :returns: :class:`GrayscaleRasterImage`
+    Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
+
+    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+
   .. php:method:: toBlackAndWhite ()
+
+    Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
+
+    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
 
   .. php:method:: toIndexed ()
 
-      :returns: :class:`IndexedRasterImage`
+    Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
+
+    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+
   .. php:staticmethod:: create ($width, $height, array $data=null, $maxVal=255)
 

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -6,11 +6,9 @@ GrayscaleRasterImage
   .. php:method:: getWidth ()
 
       :returns: int
-
   .. php:method:: getHeight ()
 
       :returns: int
-
   .. php:method:: setPixel (int $x, int $y, int $value)
 
       :param int $x: X co-ordinate
@@ -22,28 +20,23 @@ GrayscaleRasterImage
       :param int $x: X co-ordinate
       :param int $y: Y co-ordinate
       :returns: int
-
   .. php:method:: getMaxVal ()
 
   .. php:method:: getRasterData ()
 
       :returns: string
-
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
       :returns: :class:`RgbRasterImage`
-
   .. php:method:: toGrayscale ()
 
       :returns: :class:`GrayscaleRasterImage`
-
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
 
       :returns: :class:`IndexedRasterImage`
-
   .. php:staticmethod:: create ($width, $height, array $data=null, $maxVal=255)
 

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -48,7 +48,7 @@ GrayscaleRasterImage
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
     :param int $srcColor:
-    :param $destImage:
+    :param :class:`RasterImage` $destImage:
 
   .. php:method:: toRgb ()
 
@@ -74,7 +74,7 @@ GrayscaleRasterImage
 
     :returns: :class:`IndexedRasterImage` An paletted version of the image.
 
-  .. php:staticmethod:: create ($width, $height, array $data=null, $maxVal=255)
+  .. php:staticmethod:: create ($width, $height, array $data, $maxVal)
 
     :param $width:
     :param $height:

--- a/docs/api/grayscalerasterimage.rst
+++ b/docs/api/grayscalerasterimage.rst
@@ -3,17 +3,17 @@ GrayscaleRasterImage
 
 .. php:class:: GrayscaleRasterImage
 
-  .. php:method:: getWidth ()
+  .. php:method:: getWidth () -> int
 
     Get the width of the image in pixels.
 
-    :returns: int The width of the image in pixels.
+    :returns: int -- The width of the image in pixels.
 
-  .. php:method:: getHeight ()
+  .. php:method:: getHeight () -> int
 
     Get the height of the image in pixels.
 
-    :returns: int The height of the image in pixels.
+    :returns: int -- The height of the image in pixels.
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
@@ -26,7 +26,7 @@ GrayscaleRasterImage
     :param int $value:
       Value to set
 
-  .. php:method:: getPixel (int $x, int $y)
+  .. php:method:: getPixel (int $x, int $y) -> int
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
@@ -34,47 +34,47 @@ GrayscaleRasterImage
       X co-ordinate
     :param int $y:
       Y co-ordinate
-    :returns: int The value of the pixel at ($x, $y).
+    :returns: int -- The value of the pixel at ($x, $y).
 
   .. php:method:: getMaxVal ()
 
 
-  .. php:method:: getRasterData ()
+  .. php:method:: getRasterData () -> string
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
 
-    :returns: string A binary string representation of the raster data for this image.
+    :returns: string -- A binary string representation of the raster data for this image.
 
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
     :param int $srcColor:
-    :param :class:`RasterImage` $destImage:
+    :param RasterImage $destImage:
 
-  .. php:method:: toRgb ()
+  .. php:method:: toRgb () -> RgbRasterImage
 
     Produce a copy of this :class:`RasterImage` in the RGB colorspace.
 
-    :returns: :class:`RgbRasterImage` An RGB version of the image.
+    :returns: :class:`RgbRasterImage` -- An RGB version of the image.
 
-  .. php:method:: toGrayscale ()
+  .. php:method:: toGrayscale () -> GrayscaleRasterImage
 
     Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
 
-    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+    :returns: :class:`GrayscaleRasterImage` -- A monochrome version of the image.
 
-  .. php:method:: toBlackAndWhite ()
+  .. php:method:: toBlackAndWhite () -> BlackAndWhiteRasterImage
 
     Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
 
-    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
+    :returns: :class:`BlackAndWhiteRasterImage` -- a black and white version of the image.
 
-  .. php:method:: toIndexed ()
+  .. php:method:: toIndexed () -> IndexedRasterImage
 
     Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
 
-    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+    :returns: :class:`IndexedRasterImage` -- An paletted version of the image.
 
-  .. php:staticmethod:: create ($width, $height, array $data, $maxVal)
+  .. php:staticmethod:: create ($width, $height[, array $data, $maxVal])
 
     :param $width:
     :param $height:

--- a/docs/api/image.rst
+++ b/docs/api/image.rst
@@ -9,3 +9,7 @@ Image
 
   .. php:method:: create (int $width, int $height, int $impl=self::IMAGE_BLACK_WHITE)
 
+    :param int $width:
+    :param int $height:
+    :param int $impl:
+

--- a/docs/api/image.rst
+++ b/docs/api/image.rst
@@ -7,13 +7,13 @@ Image
 
     :param string $filename:
 
-  .. php:staticmethod:: fromBlob (string $blob, string $filename=null)
+  .. php:staticmethod:: fromBlob (string $blob, string $filename)
 
     :param string $blob:
     :param string $filename:
       Default: ``null``
 
-  .. php:method:: create (int $width, int $height, int $impl=self::IMAGE_BLACK_WHITE)
+  .. php:method:: create (int $width, int $height, int $impl)
 
     :param int $width:
     :param int $height:

--- a/docs/api/image.rst
+++ b/docs/api/image.rst
@@ -5,7 +5,12 @@ Image
 
   .. php:staticmethod:: fromFile (string $filename)
 
+    :param string $filename:
+
   .. php:staticmethod:: fromBlob (string $blob, string $filename=null)
+
+    :param string $blob:
+    :param string $filename:
 
   .. php:method:: create (int $width, int $height, int $impl=self::IMAGE_BLACK_WHITE)
 

--- a/docs/api/image.rst
+++ b/docs/api/image.rst
@@ -7,13 +7,13 @@ Image
 
     :param string $filename:
 
-  .. php:staticmethod:: fromBlob (string $blob, string $filename)
+  .. php:staticmethod:: fromBlob (string $blob[, string $filename])
 
     :param string $blob:
     :param string $filename:
       Default: ``null``
 
-  .. php:method:: create (int $width, int $height, int $impl)
+  .. php:method:: create (int $width, int $height[, int $impl])
 
     :param int $width:
     :param int $height:

--- a/docs/api/image.rst
+++ b/docs/api/image.rst
@@ -13,7 +13,7 @@ Image
     :param string $filename:
       Default: ``null``
 
-  .. php:method:: create (int $width, int $height[, int $impl])
+  .. php:staticmethod:: create (int $width, int $height[, int $impl])
 
     :param int $width:
     :param int $height:

--- a/docs/api/image.rst
+++ b/docs/api/image.rst
@@ -11,10 +11,12 @@ Image
 
     :param string $blob:
     :param string $filename:
+      Default: ``null``
 
   .. php:method:: create (int $width, int $height, int $impl=self::IMAGE_BLACK_WHITE)
 
     :param int $width:
     :param int $height:
     :param int $impl:
+      Default: ``self::IMAGE_BLACK_WHITE``
 

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -8,11 +8,9 @@ IndexedRasterImage
   .. php:method:: getRasterData ()
 
       :returns: string
-
   .. php:method:: getHeight ()
 
       :returns: int
-
   .. php:method:: getMaxVal ()
 
   .. php:method:: setPixel (int $x, int $y, int $value)
@@ -24,27 +22,22 @@ IndexedRasterImage
   .. php:method:: toRgb ()
 
       :returns: :class:`RgbRasterImage`
-
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toGrayscale ()
 
       :returns: :class:`GrayscaleRasterImage`
-
   .. php:method:: getPixel (int $x, int $y)
 
       :param int $x: X co-ordinate
       :param int $y: Y co-ordinate
       :returns: int
-
   .. php:method:: getWidth ()
 
       :returns: int
-
   .. php:method:: toIndexed ()
 
       :returns: :class:`IndexedRasterImage`
-
   .. php:method:: indexToRgb (int $index)
 
   .. php:method:: rgbToIndex (array $rgb)

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -7,23 +7,43 @@ IndexedRasterImage
 
   .. php:method:: getRasterData ()
 
+      :returns: string
+
   .. php:method:: getHeight ()
+
+      :returns: int
 
   .. php:method:: getMaxVal ()
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :param int $value: Value to set
+
   .. php:method:: toRgb ()
+
+      :returns: :class:`RgbRasterImage`
 
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toGrayscale ()
 
+      :returns: :class:`GrayscaleRasterImage`
+
   .. php:method:: getPixel (int $x, int $y)
+
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :returns: int
 
   .. php:method:: getWidth ()
 
+      :returns: int
+
   .. php:method:: toIndexed ()
+
+      :returns: :class:`IndexedRasterImage`
 
   .. php:method:: indexToRgb (int $index)
 

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -6,17 +6,17 @@ IndexedRasterImage
   .. php:method:: getPalette ()
 
 
-  .. php:method:: getRasterData ()
+  .. php:method:: getRasterData () -> string
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
 
-    :returns: string A binary string representation of the raster data for this image.
+    :returns: string -- A binary string representation of the raster data for this image.
 
-  .. php:method:: getHeight ()
+  .. php:method:: getHeight () -> int
 
     Get the height of the image in pixels.
 
-    :returns: int The height of the image in pixels.
+    :returns: int -- The height of the image in pixels.
 
   .. php:method:: getMaxVal ()
 
@@ -32,25 +32,25 @@ IndexedRasterImage
     :param int $value:
       Value to set
 
-  .. php:method:: toRgb ()
+  .. php:method:: toRgb () -> RgbRasterImage
 
     Produce a copy of this :class:`RasterImage` in the RGB colorspace.
 
-    :returns: :class:`RgbRasterImage` An RGB version of the image.
+    :returns: :class:`RgbRasterImage` -- An RGB version of the image.
 
-  .. php:method:: toBlackAndWhite ()
+  .. php:method:: toBlackAndWhite () -> BlackAndWhiteRasterImage
 
     Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
 
-    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
+    :returns: :class:`BlackAndWhiteRasterImage` -- a black and white version of the image.
 
-  .. php:method:: toGrayscale ()
+  .. php:method:: toGrayscale () -> GrayscaleRasterImage
 
     Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
 
-    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+    :returns: :class:`GrayscaleRasterImage` -- A monochrome version of the image.
 
-  .. php:method:: getPixel (int $x, int $y)
+  .. php:method:: getPixel (int $x, int $y) -> int
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
@@ -58,19 +58,19 @@ IndexedRasterImage
       X co-ordinate
     :param int $y:
       Y co-ordinate
-    :returns: int The value of the pixel at ($x, $y).
+    :returns: int -- The value of the pixel at ($x, $y).
 
-  .. php:method:: getWidth ()
+  .. php:method:: getWidth () -> int
 
     Get the width of the image in pixels.
 
-    :returns: int The width of the image in pixels.
+    :returns: int -- The width of the image in pixels.
 
-  .. php:method:: toIndexed ()
+  .. php:method:: toIndexed () -> IndexedRasterImage
 
     Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
 
-    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+    :returns: :class:`IndexedRasterImage` -- An paletted version of the image.
 
   .. php:method:: indexToRgb (int $index)
 
@@ -83,7 +83,7 @@ IndexedRasterImage
   .. php:method:: getTransparentColor ()
 
 
-  .. php:method:: setTransparentColor (int $color)
+  .. php:method:: setTransparentColor ([])
 
     :param int $color:
       Default: ``null``
@@ -104,7 +104,7 @@ IndexedRasterImage
 
     :param array $color:
 
-  .. php:staticmethod:: create (int $width, int $height, array $data, array $palette, int $maxVal)
+  .. php:staticmethod:: create (int $width, int $height[, array $data, array $palette, int $maxVal])
 
     :param int $width:
     :param int $height:

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -83,7 +83,7 @@ IndexedRasterImage
   .. php:method:: getTransparentColor ()
 
 
-  .. php:method:: setTransparentColor (int $color=null)
+  .. php:method:: setTransparentColor (int $color)
 
     :param int $color:
       Default: ``null``
@@ -104,7 +104,7 @@ IndexedRasterImage
 
     :param array $color:
 
-  .. php:staticmethod:: create (int $width, int $height, array $data=null, array $palette=null, int $maxVal=255)
+  .. php:staticmethod:: create (int $width, int $height, array $data, array $palette, int $maxVal)
 
     :param int $width:
     :param int $height:

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -5,6 +5,7 @@ IndexedRasterImage
 
   .. php:method:: getPalette ()
 
+
   .. php:method:: getRasterData ()
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
@@ -18,6 +19,7 @@ IndexedRasterImage
     :returns: int The height of the image in pixels.
 
   .. php:method:: getMaxVal ()
+
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
@@ -67,19 +69,34 @@ IndexedRasterImage
 
   .. php:method:: indexToRgb (int $index)
 
+    :param int $index:
+
   .. php:method:: rgbToIndex (array $rgb)
+
+    :param array $rgb:
 
   .. php:method:: getTransparentColor ()
 
+
   .. php:method:: setTransparentColor (int $color=null)
+
+    :param int $color:
 
   .. php:method:: setPalette (array $palette)
 
+    :param array $palette:
+
   .. php:method:: setMaxVal (int $maxVal)
+
+    :param int $maxVal:
 
   .. php:method:: allocateColor (array $color)
 
+    :param array $color:
+
   .. php:method:: deallocateColor (array $color)
+
+    :param array $color:
 
   .. php:staticmethod:: create (int $width, int $height, array $data=null, array $palette=null, int $maxVal=255)
 

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -100,3 +100,9 @@ IndexedRasterImage
 
   .. php:staticmethod:: create (int $width, int $height, array $data=null, array $palette=null, int $maxVal=255)
 
+    :param int $width:
+    :param int $height:
+    :param array $data:
+    :param array $palette:
+    :param int $maxVal:
+

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -7,37 +7,64 @@ IndexedRasterImage
 
   .. php:method:: getRasterData ()
 
-      :returns: string
+    Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
+
+    :returns: string A binary string representation of the raster data for this image.
+
   .. php:method:: getHeight ()
 
-      :returns: int
+    Get the height of the image in pixels.
+
+    :returns: int The height of the image in pixels.
+
   .. php:method:: getMaxVal ()
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :param int $value: Value to set
+    Set the value of a given pixel.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :param int $value: Value to set
 
   .. php:method:: toRgb ()
 
-      :returns: :class:`RgbRasterImage`
+    Produce a copy of this :class:`RasterImage` in the RGB colorspace.
+
+    :returns: :class:`RgbRasterImage` An RGB version of the image.
+
   .. php:method:: toBlackAndWhite ()
+
+    Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
+
+    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
 
   .. php:method:: toGrayscale ()
 
-      :returns: :class:`GrayscaleRasterImage`
+    Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
+
+    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+
   .. php:method:: getPixel (int $x, int $y)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :returns: int
+    Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :returns: int The value of the pixel at ($x, $y).
+
   .. php:method:: getWidth ()
 
-      :returns: int
+    Get the width of the image in pixels.
+
+    :returns: int The width of the image in pixels.
+
   .. php:method:: toIndexed ()
 
-      :returns: :class:`IndexedRasterImage`
+    Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
+
+    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+
   .. php:method:: indexToRgb (int $index)
 
   .. php:method:: rgbToIndex (array $rgb)

--- a/docs/api/indexedrasterimage.rst
+++ b/docs/api/indexedrasterimage.rst
@@ -25,9 +25,12 @@ IndexedRasterImage
 
     Set the value of a given pixel.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
-    :param int $value: Value to set
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
+    :param int $value:
+      Value to set
 
   .. php:method:: toRgb ()
 
@@ -51,8 +54,10 @@ IndexedRasterImage
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
     :returns: int The value of the pixel at ($x, $y).
 
   .. php:method:: getWidth ()
@@ -81,6 +86,7 @@ IndexedRasterImage
   .. php:method:: setTransparentColor (int $color=null)
 
     :param int $color:
+      Default: ``null``
 
   .. php:method:: setPalette (array $palette)
 
@@ -103,6 +109,9 @@ IndexedRasterImage
     :param int $width:
     :param int $height:
     :param array $data:
+      Default: ``null``
     :param array $palette:
+      Default: ``null``
     :param int $maxVal:
+      Default: ``255``
 

--- a/docs/api/palettegenerator.rst
+++ b/docs/api/palettegenerator.rst
@@ -5,9 +5,13 @@ PaletteGenerator
 
   .. php:staticmethod:: monochromePalette ()
 
+
   .. php:staticmethod:: blackAndWhitePalette ()
+
 
   .. php:staticmethod:: colorPalette ()
 
+
   .. php:staticmethod:: whitePalette ()
+
 

--- a/docs/api/rasterimage.rst
+++ b/docs/api/rasterimage.rst
@@ -27,15 +27,18 @@ Generic interface to raster images.
 
     Produce a new :class:`RasterImage` based on this one. The new image will be scaled to the requested dimensions via resampling.
 
-    :param int $width: The width of the returned image.
-    :param int $height: The height of the returned image.
+    :param int $width:
+      The width of the returned image.
+    :param int $height:
+      The height of the returned image.
     :returns: :class:`RasterImage` A scaled version of the image.
 
   .. php:method:: write (string $filename)
 
     Write the image to a file. The output format is determined by the file extension.
 
-    :param string $filename: Filename to write to.
+    :param string $filename:
+      Filename to write to.
 
   .. php:method:: toRgb ()
 
@@ -47,17 +50,22 @@ Generic interface to raster images.
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
     :returns: int The value of the pixel at ($x, $y).
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
     Set the value of a given pixel.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
-    :param int $value: Value to set
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
+    :param int $value:
+      Value to set
 
   .. php:method:: toGrayscale ()
 

--- a/docs/api/rasterimage.rst
+++ b/docs/api/rasterimage.rst
@@ -5,25 +5,25 @@ Generic interface to raster images.
 
 .. php:interface:: RasterImage
 
-  .. php:method:: getWidth ()
+  .. php:method:: getWidth () -> int
 
     Get the width of the image in pixels.
 
-    :returns: int The width of the image in pixels.
+    :returns: int -- The width of the image in pixels.
 
-  .. php:method:: getHeight ()
+  .. php:method:: getHeight () -> int
 
     Get the height of the image in pixels.
 
-    :returns: int The height of the image in pixels.
+    :returns: int -- The height of the image in pixels.
 
-  .. php:method:: getRasterData ()
+  .. php:method:: getRasterData () -> string
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
 
-    :returns: string A binary string representation of the raster data for this image.
+    :returns: string -- A binary string representation of the raster data for this image.
 
-  .. php:method:: scale (int $width, int $height)
+  .. php:method:: scale (int $width, int $height) -> RasterImage
 
     Produce a new :class:`RasterImage` based on this one. The new image will be scaled to the requested dimensions via resampling.
 
@@ -31,7 +31,7 @@ Generic interface to raster images.
       The width of the returned image.
     :param int $height:
       The height of the returned image.
-    :returns: :class:`RasterImage` A scaled version of the image.
+    :returns: :class:`RasterImage` -- A scaled version of the image.
 
   .. php:method:: write (string $filename)
 
@@ -40,13 +40,13 @@ Generic interface to raster images.
     :param string $filename:
       Filename to write to.
 
-  .. php:method:: toRgb ()
+  .. php:method:: toRgb () -> RgbRasterImage
 
     Produce a copy of this :class:`RasterImage` in the RGB colorspace.
 
-    :returns: :class:`RgbRasterImage` An RGB version of the image.
+    :returns: :class:`RgbRasterImage` -- An RGB version of the image.
 
-  .. php:method:: getPixel (int $x, int $y)
+  .. php:method:: getPixel (int $x, int $y) -> int
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
@@ -54,7 +54,7 @@ Generic interface to raster images.
       X co-ordinate
     :param int $y:
       Y co-ordinate
-    :returns: int The value of the pixel at ($x, $y).
+    :returns: int -- The value of the pixel at ($x, $y).
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
@@ -67,21 +67,21 @@ Generic interface to raster images.
     :param int $value:
       Value to set
 
-  .. php:method:: toGrayscale ()
+  .. php:method:: toGrayscale () -> GrayscaleRasterImage
 
     Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
 
-    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+    :returns: :class:`GrayscaleRasterImage` -- A monochrome version of the image.
 
-  .. php:method:: toBlackAndWhite ()
+  .. php:method:: toBlackAndWhite () -> BlackAndWhiteRasterImage
 
     Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
 
-    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
+    :returns: :class:`BlackAndWhiteRasterImage` -- a black and white version of the image.
 
-  .. php:method:: toIndexed ()
+  .. php:method:: toIndexed () -> IndexedRasterImage
 
     Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
 
-    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+    :returns: :class:`IndexedRasterImage` -- An paletted version of the image.
 

--- a/docs/api/rasterimage.rst
+++ b/docs/api/rasterimage.rst
@@ -5,23 +5,49 @@ RasterImage
 
   .. php:method:: getWidth ()
 
+      :returns: int
+
   .. php:method:: getHeight ()
+
+      :returns: int
 
   .. php:method:: getRasterData ()
 
+      :returns: string
+
   .. php:method:: scale (int $width, int $height)
+
+      :param int $width: The width of the returned image.
+      :param int $height: The height of the returned image.
+      :returns: :class:`RasterImage`
 
   .. php:method:: write (string $filename)
 
+      :param string $filename: Filename to write to.
+
   .. php:method:: toRgb ()
+
+      :returns: :class:`RgbRasterImage`
 
   .. php:method:: getPixel (int $x, int $y)
 
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :returns: int
+
   .. php:method:: setPixel (int $x, int $y, int $value)
 
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :param int $value: Value to set
+
   .. php:method:: toGrayscale ()
+
+      :returns: :class:`GrayscaleRasterImage`
 
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
+
+      :returns: :class:`IndexedRasterImage`
 

--- a/docs/api/rasterimage.rst
+++ b/docs/api/rasterimage.rst
@@ -1,9 +1,9 @@
 RasterImage
 ===========
 
-.. php:interface:: RasterImage
+Generic interface to raster images.
 
-  Generic interface to raster images.
+.. php:interface:: RasterImage
 
   .. php:method:: getWidth ()
 

--- a/docs/api/rasterimage.rst
+++ b/docs/api/rasterimage.rst
@@ -6,21 +6,17 @@ RasterImage
   .. php:method:: getWidth ()
 
       :returns: int
-
   .. php:method:: getHeight ()
 
       :returns: int
-
   .. php:method:: getRasterData ()
 
       :returns: string
-
   .. php:method:: scale (int $width, int $height)
 
       :param int $width: The width of the returned image.
       :param int $height: The height of the returned image.
       :returns: :class:`RasterImage`
-
   .. php:method:: write (string $filename)
 
       :param string $filename: Filename to write to.
@@ -28,13 +24,11 @@ RasterImage
   .. php:method:: toRgb ()
 
       :returns: :class:`RgbRasterImage`
-
   .. php:method:: getPixel (int $x, int $y)
 
       :param int $x: X co-ordinate
       :param int $y: Y co-ordinate
       :returns: int
-
   .. php:method:: setPixel (int $x, int $y, int $value)
 
       :param int $x: X co-ordinate
@@ -44,10 +38,8 @@ RasterImage
   .. php:method:: toGrayscale ()
 
       :returns: :class:`GrayscaleRasterImage`
-
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
 
       :returns: :class:`IndexedRasterImage`
-

--- a/docs/api/rasterimage.rst
+++ b/docs/api/rasterimage.rst
@@ -1,45 +1,79 @@
 RasterImage
 ===========
 
-.. php:class:: RasterImage
+.. php:interface:: RasterImage
+
+  Generic interface to raster images.
 
   .. php:method:: getWidth ()
 
-      :returns: int
+    Get the width of the image in pixels.
+
+    :returns: int The width of the image in pixels.
+
   .. php:method:: getHeight ()
 
-      :returns: int
+    Get the height of the image in pixels.
+
+    :returns: int The height of the image in pixels.
+
   .. php:method:: getRasterData ()
 
-      :returns: string
+    Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
+
+    :returns: string A binary string representation of the raster data for this image.
+
   .. php:method:: scale (int $width, int $height)
 
-      :param int $width: The width of the returned image.
-      :param int $height: The height of the returned image.
-      :returns: :class:`RasterImage`
+    Produce a new :class:`RasterImage` based on this one. The new image will be scaled to the requested dimensions via resampling.
+
+    :param int $width: The width of the returned image.
+    :param int $height: The height of the returned image.
+    :returns: :class:`RasterImage` A scaled version of the image.
+
   .. php:method:: write (string $filename)
 
-      :param string $filename: Filename to write to.
+    Write the image to a file. The output format is determined by the file extension.
+
+    :param string $filename: Filename to write to.
 
   .. php:method:: toRgb ()
 
-      :returns: :class:`RgbRasterImage`
+    Produce a copy of this :class:`RasterImage` in the RGB colorspace.
+
+    :returns: :class:`RgbRasterImage` An RGB version of the image.
+
   .. php:method:: getPixel (int $x, int $y)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :returns: int
+    Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :returns: int The value of the pixel at ($x, $y).
+
   .. php:method:: setPixel (int $x, int $y, int $value)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :param int $value: Value to set
+    Set the value of a given pixel.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :param int $value: Value to set
 
   .. php:method:: toGrayscale ()
 
-      :returns: :class:`GrayscaleRasterImage`
+    Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
+
+    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+
   .. php:method:: toBlackAndWhite ()
+
+    Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
+
+    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
 
   .. php:method:: toIndexed ()
 
-      :returns: :class:`IndexedRasterImage`
+    Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
+
+    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -28,8 +28,10 @@ RgbRasterImage
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
     :returns: int The value of the pixel at ($x, $y).
 
   .. php:method:: indexToRgb (int $val)
@@ -44,9 +46,12 @@ RgbRasterImage
 
     Set the value of a given pixel.
 
-    :param int $x: X co-ordinate
-    :param int $y: Y co-ordinate
-    :param int $value: Value to set
+    :param int $x:
+      X co-ordinate
+    :param int $y:
+      Y co-ordinate
+    :param int $value:
+      Value to set
 
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
@@ -92,7 +97,9 @@ RgbRasterImage
     :param $width:
     :param $height:
     :param array $data:
+      Default: ``null``
     :param $maxVal:
+      Default: ``255``
 
   .. php:staticmethod:: convertDepth (&$item, $key, array $data)
 

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -23,6 +23,7 @@ RgbRasterImage
 
   .. php:method:: getMaxVal ()
 
+
   .. php:method:: getPixel (int $x, int $y)
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
@@ -33,7 +34,11 @@ RgbRasterImage
 
   .. php:method:: indexToRgb (int $val)
 
+    :param int $val:
+
   .. php:method:: rgbToIndex (array $val)
+
+    :param array $val:
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
@@ -44,6 +49,9 @@ RgbRasterImage
     :param int $value: Value to set
 
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
+
+    :param int $srcColor:
+    :param $destImage:
 
   .. php:method:: toRgb ()
 

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -6,15 +6,12 @@ RgbRasterImage
   .. php:method:: getWidth ()
 
       :returns: int
-
   .. php:method:: getHeight ()
 
       :returns: int
-
   .. php:method:: getRasterData ()
 
       :returns: string
-
   .. php:method:: getMaxVal ()
 
   .. php:method:: getPixel (int $x, int $y)
@@ -22,7 +19,6 @@ RgbRasterImage
       :param int $x: X co-ordinate
       :param int $y: Y co-ordinate
       :returns: int
-
   .. php:method:: indexToRgb (int $val)
 
   .. php:method:: rgbToIndex (array $val)
@@ -38,17 +34,14 @@ RgbRasterImage
   .. php:method:: toRgb ()
 
       :returns: :class:`RgbRasterImage`
-
   .. php:method:: toGrayscale ()
 
       :returns: :class:`GrayscaleRasterImage`
-
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
 
       :returns: :class:`IndexedRasterImage`
-
   .. php:staticmethod:: rgbToInt (int $r, int $g, int $b)
 
   .. php:staticmethod:: intToRgb ($in)

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -56,7 +56,7 @@ RgbRasterImage
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
     :param int $srcColor:
-    :param $destImage:
+    :param :class:`RasterImage` $destImage:
 
   .. php:method:: toRgb ()
 
@@ -92,7 +92,7 @@ RgbRasterImage
 
     :param $in:
 
-  .. php:staticmethod:: create ($width, $height, array $data=null, $maxVal=255)
+  .. php:staticmethod:: create ($width, $height, array $data, $maxVal)
 
     :param $width:
     :param $height:
@@ -101,9 +101,9 @@ RgbRasterImage
     :param $maxVal:
       Default: ``255``
 
-  .. php:staticmethod:: convertDepth (&$item, $key, array $data)
+  .. php:staticmethod:: convertDepth (& $item, $key, array $data)
 
-    :param :class:`&` $item:
+    :param & $item:
     :param $key:
     :param array $data:
 

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -5,43 +5,70 @@ RgbRasterImage
 
   .. php:method:: getWidth ()
 
-      :returns: int
+    Get the width of the image in pixels.
+
+    :returns: int The width of the image in pixels.
+
   .. php:method:: getHeight ()
 
-      :returns: int
+    Get the height of the image in pixels.
+
+    :returns: int The height of the image in pixels.
+
   .. php:method:: getRasterData ()
 
-      :returns: string
+    Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
+
+    :returns: string A binary string representation of the raster data for this image.
+
   .. php:method:: getMaxVal ()
 
   .. php:method:: getPixel (int $x, int $y)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :returns: int
+    Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :returns: int The value of the pixel at ($x, $y).
+
   .. php:method:: indexToRgb (int $val)
 
   .. php:method:: rgbToIndex (array $val)
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
-      :param int $x: X co-ordinate
-      :param int $y: Y co-ordinate
-      :param int $value: Value to set
+    Set the value of a given pixel.
+
+    :param int $x: X co-ordinate
+    :param int $y: Y co-ordinate
+    :param int $value: Value to set
 
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
-      :returns: :class:`RgbRasterImage`
+    Produce a copy of this :class:`RasterImage` in the RGB colorspace.
+
+    :returns: :class:`RgbRasterImage` An RGB version of the image.
+
   .. php:method:: toGrayscale ()
 
-      :returns: :class:`GrayscaleRasterImage`
+    Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
+
+    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+
   .. php:method:: toBlackAndWhite ()
+
+    Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
+
+    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
 
   .. php:method:: toIndexed ()
 
-      :returns: :class:`IndexedRasterImage`
+    Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
+
+    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+
   .. php:staticmethod:: rgbToInt (int $r, int $g, int $b)
 
   .. php:staticmethod:: intToRgb ($in)

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -79,9 +79,24 @@ RgbRasterImage
 
   .. php:staticmethod:: rgbToInt (int $r, int $g, int $b)
 
+    :param int $r:
+    :param int $g:
+    :param int $b:
+
   .. php:staticmethod:: intToRgb ($in)
+
+    :param $in:
 
   .. php:staticmethod:: create ($width, $height, array $data=null, $maxVal=255)
 
+    :param $width:
+    :param $height:
+    :param array $data:
+    :param $maxVal:
+
   .. php:staticmethod:: convertDepth (&$item, $key, array $data)
+
+    :param :class:`&` $item:
+    :param $key:
+    :param array $data:
 

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -3,28 +3,28 @@ RgbRasterImage
 
 .. php:class:: RgbRasterImage
 
-  .. php:method:: getWidth ()
+  .. php:method:: getWidth () -> int
 
     Get the width of the image in pixels.
 
-    :returns: int The width of the image in pixels.
+    :returns: int -- The width of the image in pixels.
 
-  .. php:method:: getHeight ()
+  .. php:method:: getHeight () -> int
 
     Get the height of the image in pixels.
 
-    :returns: int The height of the image in pixels.
+    :returns: int -- The height of the image in pixels.
 
-  .. php:method:: getRasterData ()
+  .. php:method:: getRasterData () -> string
 
     Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
 
-    :returns: string A binary string representation of the raster data for this image.
+    :returns: string -- A binary string representation of the raster data for this image.
 
   .. php:method:: getMaxVal ()
 
 
-  .. php:method:: getPixel (int $x, int $y)
+  .. php:method:: getPixel (int $x, int $y) -> int
 
     Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
 
@@ -32,7 +32,7 @@ RgbRasterImage
       X co-ordinate
     :param int $y:
       Y co-ordinate
-    :returns: int The value of the pixel at ($x, $y).
+    :returns: int -- The value of the pixel at ($x, $y).
 
   .. php:method:: indexToRgb (int $val)
 
@@ -56,31 +56,31 @@ RgbRasterImage
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
     :param int $srcColor:
-    :param :class:`RasterImage` $destImage:
+    :param RasterImage $destImage:
 
-  .. php:method:: toRgb ()
+  .. php:method:: toRgb () -> RgbRasterImage
 
     Produce a copy of this :class:`RasterImage` in the RGB colorspace.
 
-    :returns: :class:`RgbRasterImage` An RGB version of the image.
+    :returns: :class:`RgbRasterImage` -- An RGB version of the image.
 
-  .. php:method:: toGrayscale ()
+  .. php:method:: toGrayscale () -> GrayscaleRasterImage
 
     Produce a copy of this :class:`RasterImage` in a monochrome colorspace.
 
-    :returns: :class:`GrayscaleRasterImage` A monochrome version of the image.
+    :returns: :class:`GrayscaleRasterImage` -- A monochrome version of the image.
 
-  .. php:method:: toBlackAndWhite ()
+  .. php:method:: toBlackAndWhite () -> BlackAndWhiteRasterImage
 
     Produce a copy of this :class:`RasterImage` in a pure black-and-white colorspace.
 
-    :returns: :class:`BlackAndWhiteRasterImage` a black and white version of the image.
+    :returns: :class:`BlackAndWhiteRasterImage` -- a black and white version of the image.
 
-  .. php:method:: toIndexed ()
+  .. php:method:: toIndexed () -> IndexedRasterImage
 
     Produce a copy of this :class:`RasterImage` as an indexed image with an associated palette of unique colors.
 
-    :returns: :class:`IndexedRasterImage` An paletted version of the image.
+    :returns: :class:`IndexedRasterImage` -- An paletted version of the image.
 
   .. php:staticmethod:: rgbToInt (int $r, int $g, int $b)
 
@@ -92,7 +92,7 @@ RgbRasterImage
 
     :param $in:
 
-  .. php:staticmethod:: create ($width, $height, array $data, $maxVal)
+  .. php:staticmethod:: create ($width, $height[, array $data, $maxVal])
 
     :param $width:
     :param $height:

--- a/docs/api/rgbrasterimage.rst
+++ b/docs/api/rgbrasterimage.rst
@@ -5,13 +5,23 @@ RgbRasterImage
 
   .. php:method:: getWidth ()
 
+      :returns: int
+
   .. php:method:: getHeight ()
 
+      :returns: int
+
   .. php:method:: getRasterData ()
+
+      :returns: string
 
   .. php:method:: getMaxVal ()
 
   .. php:method:: getPixel (int $x, int $y)
+
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :returns: int
 
   .. php:method:: indexToRgb (int $val)
 
@@ -19,15 +29,25 @@ RgbRasterImage
 
   .. php:method:: setPixel (int $x, int $y, int $value)
 
+      :param int $x: X co-ordinate
+      :param int $y: Y co-ordinate
+      :param int $value: Value to set
+
   .. php:method:: mapColor (int $srcColor, RasterImage $destImage)
 
   .. php:method:: toRgb ()
 
+      :returns: :class:`RgbRasterImage`
+
   .. php:method:: toGrayscale ()
+
+      :returns: :class:`GrayscaleRasterImage`
 
   .. php:method:: toBlackAndWhite ()
 
   .. php:method:: toIndexed ()
+
+      :returns: :class:`IndexedRasterImage`
 
   .. php:staticmethod:: rgbToInt (int $r, int $g, int $b)
 

--- a/docs/api/util/abstractlzwdictionary.rst
+++ b/docs/api/util/abstractlzwdictionary.rst
@@ -6,11 +6,9 @@ AbstractLzwDictionary
   .. php:method:: getClearCode ()
 
       :returns: number
-
   .. php:method:: getEodCode ()
 
       :returns: number
-
   .. php:method:: __construct (int $minCodeSize)
 
   .. php:method:: getSize ()

--- a/docs/api/util/abstractlzwdictionary.rst
+++ b/docs/api/util/abstractlzwdictionary.rst
@@ -5,7 +5,11 @@ AbstractLzwDictionary
 
   .. php:method:: getClearCode ()
 
+      :returns: number
+
   .. php:method:: getEodCode ()
+
+      :returns: number
 
   .. php:method:: __construct (int $minCodeSize)
 

--- a/docs/api/util/abstractlzwdictionary.rst
+++ b/docs/api/util/abstractlzwdictionary.rst
@@ -3,13 +3,13 @@ AbstractLzwDictionary
 
 .. php:class:: AbstractLzwDictionary
 
-  .. php:method:: getClearCode ()
+  .. php:method:: getClearCode () -> number
 
-    :returns: number
+    :returns: number -- 
 
-  .. php:method:: getEodCode ()
+  .. php:method:: getEodCode () -> number
 
-    :returns: number
+    :returns: number -- 
 
   .. php:method:: __construct (int $minCodeSize)
 

--- a/docs/api/util/abstractlzwdictionary.rst
+++ b/docs/api/util/abstractlzwdictionary.rst
@@ -5,10 +5,12 @@ AbstractLzwDictionary
 
   .. php:method:: getClearCode ()
 
-      :returns: number
+    :returns: number
+
   .. php:method:: getEodCode ()
 
-      :returns: number
+    :returns: number
+
   .. php:method:: __construct (int $minCodeSize)
 
   .. php:method:: getSize ()

--- a/docs/api/util/abstractlzwdictionary.rst
+++ b/docs/api/util/abstractlzwdictionary.rst
@@ -13,9 +13,15 @@ AbstractLzwDictionary
 
   .. php:method:: __construct (int $minCodeSize)
 
+    :param int $minCodeSize:
+
   .. php:method:: getSize ()
+
 
   .. php:method:: clear ()
 
+
   .. php:method:: add (string $entry)
+
+    :param string $entry:
 

--- a/docs/api/util/lzwcompression.rst
+++ b/docs/api/util/lzwcompression.rst
@@ -7,5 +7,11 @@ Utility classes to decode or encode entire strings.
 
   .. php:staticmethod:: compress (string $inp, int $minCodeSize)
 
+    :param string $inp:
+    :param int $minCodeSize:
+
   .. php:staticmethod:: decompress (string $inp, int $minCodeSize)
+
+    :param string $inp:
+    :param int $minCodeSize:
 

--- a/docs/api/util/lzwcompression.rst
+++ b/docs/api/util/lzwcompression.rst
@@ -3,6 +3,8 @@ LzwCompression
 
 .. php:class:: LzwCompression
 
+  Utility classes to decode or encode entire strings.
+
   .. php:staticmethod:: compress (string $inp, int $minCodeSize)
 
   .. php:staticmethod:: decompress (string $inp, int $minCodeSize)

--- a/docs/api/util/lzwcompression.rst
+++ b/docs/api/util/lzwcompression.rst
@@ -1,9 +1,9 @@
 LzwCompression
 ==============
 
-.. php:class:: LzwCompression
+Utility classes to decode or encode entire strings.
 
-  Utility classes to decode or encode entire strings.
+.. php:class:: LzwCompression
 
   .. php:staticmethod:: compress (string $inp, int $minCodeSize)
 

--- a/docs/api/util/lzwdecodebuffer.rst
+++ b/docs/api/util/lzwdecodebuffer.rst
@@ -3,11 +3,13 @@ LzwDecodeBuffer
 
 .. php:class:: LzwDecodeBuffer
 
+  Treat incoming string as a stream of bits
+
   .. php:method:: __construct (string $contents)
 
   .. php:method:: read (int $readBits)
 
-      :param int $readBits: Number of bits to read
+    :param int $readBits: Number of bits to read
 
   .. php:method:: readBit (int $i)
 

--- a/docs/api/util/lzwdecodebuffer.rst
+++ b/docs/api/util/lzwdecodebuffer.rst
@@ -1,15 +1,19 @@
 LzwDecodeBuffer
 ===============
 
+Treat incoming string as a stream of bits
+
 .. php:class:: LzwDecodeBuffer
 
-  Treat incoming string as a stream of bits
-
   .. php:method:: __construct (string $contents)
+
+    :param string $contents:
 
   .. php:method:: read (int $readBits)
 
     :param int $readBits: Number of bits to read
 
   .. php:method:: readBit (int $i)
+
+    :param int $i:
 

--- a/docs/api/util/lzwdecodebuffer.rst
+++ b/docs/api/util/lzwdecodebuffer.rst
@@ -7,5 +7,7 @@ LzwDecodeBuffer
 
   .. php:method:: read (int $readBits)
 
+      :param int $readBits: Number of bits to read
+
   .. php:method:: readBit (int $i)
 

--- a/docs/api/util/lzwdecodebuffer.rst
+++ b/docs/api/util/lzwdecodebuffer.rst
@@ -11,7 +11,8 @@ Treat incoming string as a stream of bits
 
   .. php:method:: read (int $readBits)
 
-    :param int $readBits: Number of bits to read
+    :param int $readBits:
+      Number of bits to read
 
   .. php:method:: readBit (int $i)
 

--- a/docs/api/util/lzwdecodedictionary.rst
+++ b/docs/api/util/lzwdecodedictionary.rst
@@ -5,9 +5,16 @@ LzwDecodeDictionary
 
   .. php:method:: clear ()
 
+
   .. php:method:: get (int $code)
+
+    :param int $code:
 
   .. php:method:: contains (int $code)
 
+    :param int $code:
+
   .. php:method:: add (string $entry)
+
+    :param string $entry:
 

--- a/docs/api/util/lzwencodebuffer.rst
+++ b/docs/api/util/lzwencodebuffer.rst
@@ -5,7 +5,12 @@ LzwEncodeBuffer
 
   .. php:method:: __construct ()
 
+
   .. php:method:: add (int $code, int $bits)
 
+    :param int $code:
+    :param int $bits:
+
   .. php:method:: asString ()
+
 

--- a/docs/api/util/lzwencodedictionary.rst
+++ b/docs/api/util/lzwencodedictionary.rst
@@ -5,9 +5,16 @@ LzwEncodeDictionary
 
   .. php:method:: clear ()
 
+
   .. php:method:: get (string $code)
+
+    :param string $code:
 
   .. php:method:: contains (string $code)
 
+    :param string $code:
+
   .. php:method:: add (string $entry)
+
+    :param string $entry:
 

--- a/docs/doxyphp2sphinx.py
+++ b/docs/doxyphp2sphinx.py
@@ -89,12 +89,37 @@ def classXmlToRst(compounddef, title):
                 methodName = member.find('definition').text.split("::")[-1]
                 argsString = member.find('argsstring').text
                 rst += "  .. php:method:: " + methodName + " " + argsString + "\n\n"
+                dd = member.find('detaileddescription')
+                params = dd.find('*/parameterlist')
+                if params != None:
+                    for arg in params.iter('parameteritem'):
+                        argname = arg.find('parameternamelist')
+                        argnameType = argname.find('parametertype').text
+                        argnameName = argname.find('parametername').text
+                        argdesc = arg.find('parameterdescription')
+                        argdescPara = argdesc.find('para').text
+                        rst += "      :param " + argnameType + " " + argnameName + ": " + argdescPara.rstrip() + "\n"
+                ret = dd.find('*/simplesect')
+                if ret != None:
+                    para = ret.find('para')
+                    typer = para.find('ref')
+                    txt = para.text
+                    if typer != None:
+                        if txt != None:
+                            txt = ":class:`" + typer.text + "` " + txt
+                        else:
+                            txt = ":class:`" + typer.text + "` "
+                    if txt == None:
+                        txt = "mixed"
+                    rst += ("      :returns: " + txt).rstrip() + "\n"
+                if (params != None) or (ret != None):
+                    rst += "\n"
+
         elif kind == "public-static-func":
             for member in section.iter('memberdef'):
                 methodName = member.find('definition').text.split("::")[-1]
                 argsString = member.find('argsstring').text
                 rst += "  .. php:staticmethod:: " + methodName + " " + argsString + "\n\n"
-
 
             pass
         else:

--- a/docs/doxyphp2sphinx.py
+++ b/docs/doxyphp2sphinx.py
@@ -98,20 +98,11 @@ def classXmlToRst(compounddef, title):
                         argnameName = argname.find('parametername').text
                         argdesc = arg.find('parameterdescription')
                         argdescPara = argdesc.find('para').text
-                        rst += "      :param " + argnameType + " " + argnameName + ": " + argdescPara.rstrip() + "\n"
+                        rst += ("      :param " + itsatype(argnameType)).rstrip() + " " + argnameName + ": " + argdescPara.rstrip() + "\n"
                 ret = dd.find('*/simplesect')
                 if ret != None:
-                    para = ret.find('para')
-                    typer = para.find('ref')
-                    txt = para.text
-                    if typer != None:
-                        if txt != None:
-                            txt = ":class:`" + typer.text + "` " + txt
-                        else:
-                            txt = ":class:`" + typer.text + "` "
-                    if txt == None:
-                        txt = "mixed"
-                    rst += ("      :returns: " + txt).rstrip() + "\n"
+                    paras = ret.iter('para')
+                    rst += "      :returns: " + paras2rst(paras).strip()
                 if (params != None) or (ret != None):
                     rst += "\n"
 
@@ -127,6 +118,29 @@ def classXmlToRst(compounddef, title):
 
     #rst +=  .. php:method:: setDate($year, $month, $day)
     return rst
+
+def paras2rst(paras):
+    return "\n".join([para2rst(x) for x in paras])
+
+def xmldebug(inp):
+    print(ET.tostring(inp, encoding='utf8', method='xml').decode())
+
+def para2rst(inp):
+    ret = "" if inp.text is None else inp.text
+    for subtag in inp:
+        txt = subtag.text
+        if subtag.tag == "ref":
+            txt = ":class:`" + txt + "`"
+        ret += txt + ("" if subtag.tail == None else subtag.tail)
+    return ret
+
+def itsatype(inp):
+    if inp == None:
+        return ""
+    if inp in ["", "int", "string", "array", "float", "double"]:
+        return inp
+    else:
+        return ":class:`" + inp + "`"
 
 def renderClassByRefId(classRefId, name):
     print("Processing class " + name)

--- a/docs/doxyphp2sphinx.py
+++ b/docs/doxyphp2sphinx.py
@@ -100,69 +100,64 @@ def classXmlToRst(compounddef, title):
         print("  " + kind)
         if kind == "public-func":
             for member in section.iter('memberdef'):
-                documentedParams = {}
-                dd = member.find('detaileddescription')
-                
-                params = dd.find('*/parameterlist')
-                if params != None:
-                    # Use documented param list if present
-                    for arg in params.iter('parameteritem'):
-                        argname = arg.find('parameternamelist')
-                        argnameType = argname.find('parametertype').text
-                        argnameName = argname.find('parametername').text
-                        argdesc = arg.find('parameterdescription')
-                        argdescPara = argdesc.find('para').text
-                        documentedParams[argnameName] = ("    :param " + itsatype(argnameType)).rstrip() + " " + argnameName + ": " + argdescPara.rstrip() + "\n"
-                         
-            
-            
-                methodName = member.find('definition').text.split("::")[-1]
-                # TODO re-write argsString so that ", $foo = bar" shows as  " [, $foo]", and return type is included
-                argsString = member.find('argsstring').text
-                rst += "  .. php:method:: " + methodName + " " + argsString + "\n\n"
- 
-                # Member description
-                mDetailedDescriptionText = paras2rst(dd).strip();
-                if mDetailedDescriptionText != "":
-                  rst += "    " + mDetailedDescriptionText + "\n\n"
-
-                # Param list from the definition in the code and use
-                # documentation where available, auto-fill where not.
-                params = member.iter('param')
-                if params != None:
-                  for arg in params:
-                    paramKey = arg.find('declname').text
-                    if paramKey in documentedParams:
-                      # TODO apend info about default value
-                      rst += documentedParams[paramKey]
-                    else:
-                      # Undocumented param
-                      paramName = paramKey
-                      xmldebug(arg)
-                      typeEl = arg.find('type')
-                      typeStr = "" if typeEl is None else typeEl.text
-                      rst += "    :param " + (itsatype(typeStr) + " " + paramName).strip() + ":\n"
-
-                ret = dd.find('*/simplesect')
-                if ret != None:
-                    paras = ret.iter('para')
-                    rst += "    :returns: " + paras2rst(paras).strip() + "\n"
-                if (params != None) or (ret != None):
-                    rst += "\n"
-                print("    " +  methodName + " " + argsString)
-            
-            
-
+                rst += methodXmlToRst(member, 'method')
         elif kind == "public-static-func":
-            # TODO member description, arg list more like above.
             for member in section.iter('memberdef'):
-                methodName = member.find('definition').text.split("::")[-1]
-                argsString = member.find('argsstring').text
-                rst += "  .. php:staticmethod:: " + methodName + " " + argsString + "\n\n"
-
-            pass
+                rst += methodXmlToRst(member, 'staticmethod')
         else:
             print("    Skipping, no rules to print this section")
+    return rst
+
+def methodXmlToRst(member, methodType):
+    rst = ""
+    documentedParams = {}
+    dd = member.find('detaileddescription')
+    
+    params = dd.find('*/parameterlist')
+    if params != None:
+        # Use documented param list if present
+        for arg in params.iter('parameteritem'):
+            argname = arg.find('parameternamelist')
+            argnameType = argname.find('parametertype').text
+            argnameName = argname.find('parametername').text
+            argdesc = arg.find('parameterdescription')
+            argdescPara = argdesc.find('para').text
+            documentedParams[argnameName] = ("    :param " + itsatype(argnameType)).rstrip() + " " + argnameName + ": " + argdescPara.rstrip() + "\n"
+
+    methodName = member.find('definition').text.split("::")[-1]
+    # TODO re-write argsString so that ", $foo = bar" shows as  " [, $foo]", and return type is included
+    argsString = member.find('argsstring').text
+    rst += "  .. php:" + methodType + ":: " + methodName + " " + argsString + "\n\n"
+
+    # Member description
+    mDetailedDescriptionText = paras2rst(dd).strip();
+    if mDetailedDescriptionText != "":
+      rst += "    " + mDetailedDescriptionText + "\n\n"
+
+    # Param list from the definition in the code and use
+    # documentation where available, auto-fill where not.
+    params = member.iter('param')
+    if params != None:
+      for arg in params:
+        paramKey = arg.find('declname').text
+        if paramKey in documentedParams:
+          # TODO apend info about default value
+          rst += documentedParams[paramKey]
+        else:
+          # Undocumented param
+          paramName = paramKey
+          xmldebug(arg)
+          typeEl = arg.find('type')
+          typeStr = "" if typeEl is None else typeEl.text
+          rst += "    :param " + (itsatype(typeStr) + " " + paramName).strip() + ":\n"
+
+    ret = dd.find('*/simplesect')
+    if ret != None:
+        paras = ret.iter('para')
+        rst += "    :returns: " + paras2rst(paras).strip() + "\n"
+    if (params != None) or (ret != None):
+        rst += "\n"
+    print("    " +  methodName + " " + argsString)
     return rst
 
 def paras2rst(paras):

--- a/docs/doxyphp2sphinx.py
+++ b/docs/doxyphp2sphinx.py
@@ -112,6 +112,7 @@ def methodXmlToRst(member, methodType):
     rst = ""
     documentedParams = {}
     dd = member.find('detaileddescription')
+    returnInfo = retInfo(dd)
     params = dd.find('*/parameterlist')
     if params != None:
         # Use documented param list if present
@@ -129,7 +130,6 @@ def methodXmlToRst(member, methodType):
     # TODO re-write argsString so that ", $foo = bar" shows as  " [, $foo]", and return type is included
     argsString = member.find('argsstring').text
     rst += "  .. php:" + methodType + ":: " + methodName + " " + argsString + "\n\n"
-
     # Member description
     mDetailedDescriptionText = paras2rst(dd).strip();
     if mDetailedDescriptionText != "":
@@ -159,16 +159,23 @@ def methodXmlToRst(member, methodType):
         if paramDefval != None:
           rst += "      Default: ``" + paramDefval.text + "``\n"
     # Return value
-    # TODO load return info into data struct.
-    returnInfo = {}
-    ret = dd.find('*/simplesect')
-    if ret != None:
-        paras = ret.iter('para')
-        rst += "    :returns: " + paras2rst(paras).strip() + "\n"
-    if (params != None) or (ret != None):
+    if returnInfo != None:
+        if returnInfo['returnType'] != None:
+            rst += "    :returns: " + itsatype(returnInfo['returnType']) + " " + returnInfo['returnDesc'] + "\n"
+        else:
+            rst += "    :returns: " + returnInfo['returnDesc'] + "\n"
+    if (params != None) or (returnInfo != None):
         rst += "\n"
     print("    " +  methodName + " " + argsString)
     return rst
+
+def retInfo(dd):
+    ret = dd.find('*/simplesect')
+    if ret == None:
+        return None
+    paras = ret.iter('para')
+    desc = paras2rst(paras).strip()
+    return {'returnType': None, 'returnDesc': desc}
 
 def paras2rst(paras, prefix = ""):
     return "\n".join([prefix + para2rst(x) for x in paras])

--- a/docs/user/imagetypes.rst
+++ b/docs/user/imagetypes.rst
@@ -50,7 +50,7 @@ Each of these returns an image of the requested type. They work by instantiating
 Implicit conversions
 ^^^^^^^^^^^^^^^^^^^^
 
-Some file formats only accept specific types of raster data, so the :meth`RasterImage::write()` method will need to convert it. For example, this ``.pbm`` will be limited to 2 colors, which is achieved by using :meth:`RasterImage:toBlackAndWhite` in the background:
+Some file formats only accept specific types of raster data, so the :meth:`RasterImage::write()` method will need to convert it. For example, this ``.pbm`` will be limited to 2 colors, which is achieved by using :meth:`RasterImage:toBlackAndWhite` in the background:
 
 .. code-block:: php
 

--- a/src/Mike42/ImagePhp/AbstractRasterImage.php
+++ b/src/Mike42/ImagePhp/AbstractRasterImage.php
@@ -6,6 +6,11 @@ use Mike42\ImagePhp\Codec\ImageCodec;
 
 abstract class AbstractRasterImage implements RasterImage
 {
+    /**
+     * Produce a rectangle with the given properties.
+     *
+     * @param int $fill
+     */
     public function rect($startX, $startY, $width, $height, $filled = false, $outline = 1, $fill = 1)
     {
         $this -> horizontalLine($startY, $startX, $startX + $width - 1, $outline);

--- a/src/Mike42/ImagePhp/BlackAndWhiteRasterImage.php
+++ b/src/Mike42/ImagePhp/BlackAndWhiteRasterImage.php
@@ -65,7 +65,7 @@ class BlackAndWhiteRasterImage extends AbstractRasterImage
         }
     }
 
-    public function getPixel(int $x, int $y)
+    public function getPixel(int $x, int $y) : int
     {
         if ($x < 0 || $x >= $this -> width) {
             return 0;

--- a/src/Mike42/ImagePhp/GrayscaleRasterImage.php
+++ b/src/Mike42/ImagePhp/GrayscaleRasterImage.php
@@ -39,7 +39,7 @@ class GrayscaleRasterImage extends AbstractRasterImage
         $this -> data[$byte] = $value;
     }
 
-    public function getPixel(int $x, int $y)
+    public function getPixel(int $x, int $y) : int
     {
         if ($x < 0 || $x >= $this -> width) {
             return 0;

--- a/src/Mike42/ImagePhp/Image.php
+++ b/src/Mike42/ImagePhp/Image.php
@@ -39,7 +39,7 @@ class Image
         return $decoder -> decode($blob);
     }
     
-    public function create(int $width, int $height, int $impl = self::IMAGE_BLACK_WHITE)
+    public static function create(int $width, int $height, int $impl = self::IMAGE_BLACK_WHITE)
     {
         return BlackAndWhiteRasterImage::create($width, $height);
     }

--- a/src/Mike42/ImagePhp/IndexedRasterImage.php
+++ b/src/Mike42/ImagePhp/IndexedRasterImage.php
@@ -106,10 +106,10 @@ class IndexedRasterImage extends AbstractRasterImage
     public function getPixel(int $x, int $y) : int
     {
         if ($x < 0 || $x >= $this -> width) {
-            return;
+            return 0;
         }
         if ($y < 0 || $y >= $this -> height) {
-            return;
+            return 0;
         }
         $byte = $y * $this -> width + $x;
         return $this -> data[$byte];

--- a/src/Mike42/ImagePhp/IndexedRasterImage.php
+++ b/src/Mike42/ImagePhp/IndexedRasterImage.php
@@ -103,7 +103,7 @@ class IndexedRasterImage extends AbstractRasterImage
         return $img;
     }
 
-    public function getPixel(int $x, int $y)
+    public function getPixel(int $x, int $y) : int
     {
         if ($x < 0 || $x >= $this -> width) {
             return;

--- a/src/Mike42/ImagePhp/RasterImage.php
+++ b/src/Mike42/ImagePhp/RasterImage.php
@@ -16,20 +16,20 @@ interface RasterImage
     /**
      * Get the width of the image in pixels.
      *
-     * @return int
+     * @return int The width of the image in pixels.
      */
     public function getWidth(): int;
 
     /**
      * Get the height of the image in pixels.
      *
-     * @return int
+     * @return int The height of the image in pixels.
      */
     public function getHeight(): int;
 
     /**
      * Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
-     * @return string
+     * @return string A binary string representation of the raster data for this image.
      */
     public function getRasterData(): string;
 
@@ -38,7 +38,7 @@ interface RasterImage
      *
      * @param int $width The width of the returned image.
      * @param int $height The height of the returned image.
-     * @return RasterImage
+     * @return RasterImage A scaled version of the image.
      */
     public function scale(int $width, int $height): RasterImage;
     
@@ -52,7 +52,7 @@ interface RasterImage
     /**
      * Produce a copy of this RasterImage in the RGB colorspace.
      *
-     * @return RgbRasterImage
+     * @return RgbRasterImage An RGB version of the image.
      */
     public function toRgb() : RgbRasterImage;
 
@@ -61,7 +61,7 @@ interface RasterImage
      *
      * @param int $x X co-ordinate
      * @param int $y Y co-ordinate
-     * @return int
+     * @return int The value of the pixel at ($x, $y).
      */
     public function getPixel(int $x, int $y) : int;
 
@@ -76,19 +76,20 @@ interface RasterImage
     /**
      * Produce a copy of this RasterImage in a monochrome colorspace.
      *
-     * @return GrayscaleRasterImage
+     * @return GrayscaleRasterImage A monochrome version of the image.
      */
     public function toGrayscale() : GrayscaleRasterImage;
 
     /**
      * Produce a copy of this RasterImage in a pure black-and-white colorspace.
+     * @return BlackAndWhiteRasterImage a black and white version of the image.
      */
     public function toBlackAndWhite() : BlackAndWhiteRasterImage;
 
     /**
      * Produce a copy of this RasterImage as an indexed image with an associated palette of unique colors.
      *
-     * @return IndexedRasterImage
+     * @return IndexedRasterImage An paletted version of the image.
      */
     public function toIndexed() : IndexedRasterImage;
 }

--- a/src/Mike42/ImagePhp/RasterImage.php
+++ b/src/Mike42/ImagePhp/RasterImage.php
@@ -1,28 +1,94 @@
 <?php
+// This file is part of mike42/image-php, which is released under LGPL-2.1-or-later.
+// See file LICENSE or go to https://github.com/mike42/image-php for full license details
 
+/**
+ * Top-level namespace for Mike42\ImagePhp, containing the classes and
+ * interfaces that a provide an entry-point into the library.
+ */
 namespace Mike42\ImagePhp;
 
+/**
+ * Generic interface to raster images.
+ */
 interface RasterImage
 {
+    /**
+     * Get the width of the image in pixels.
+     *
+     * @return int
+     */
     public function getWidth(): int;
-    
+
+    /**
+     * Get the height of the image in pixels.
+     *
+     * @return int
+     */
     public function getHeight(): int;
-    
+
+    /**
+     * Get a binary string representing the underlying image data. The formatting of this data is implementation-dependent.
+     * @return string
+     */
     public function getRasterData(): string;
-    
+
+    /**
+     * Produce a new RasterImage based on this one. The new image will be scaled to the requested dimensions via resampling. 
+     *
+     * @param int $width The width of the returned image.
+     * @param int $height The height of the returned image.
+     * @return RasterImage
+     */
     public function scale(int $width, int $height): RasterImage;
     
+    /**
+     * Write the image to a file. The output format is determined by the file extension.
+     *
+     * @param string $filename Filename to write to.
+     */
     public function write(string $filename);
-    
+
+    /**
+     * Produce a copy of this RasterImage in the RGB colorspace.
+     *
+     * @return RgbRasterImage
+     */
     public function toRgb() : RgbRasterImage;
-    
-    public function getPixel(int $x, int $y);
-    
+
+    /**
+     * Get the value of a given pixel. The meaning of the integer value of this pixel is implementation-dependent.
+     *
+     * @param int $x X co-ordinate
+     * @param int $y Y co-ordinate
+     * @return int
+     */
+    public function getPixel(int $x, int $y) : int;
+
+    /**
+     * Set the value of a given pixel.
+     * @param int $x X co-ordinate
+     * @param int $y Y co-ordinate
+     * @param int $value Value to set
+     */
     public function setPixel(int $x, int $y, int $value);
-    
+
+    /**
+     * Produce a copy of this RasterImage in a monochrome colorspace.
+     *
+     * @return GrayscaleRasterImage
+     */
     public function toGrayscale() : GrayscaleRasterImage;
-    
+
+    /**
+     * Produce a copy of this RasterImage in a pure black-and-white colorspace.
+     */
     public function toBlackAndWhite() : BlackAndWhiteRasterImage;
-    
+
+    /**
+     * Produce a copy of this RasterImage as an indexed image with an associated palette of unique colors.
+     *
+     * @return IndexedRasterImage
+     */
     public function toIndexed() : IndexedRasterImage;
 }

--- a/src/Mike42/ImagePhp/RasterImage.php
+++ b/src/Mike42/ImagePhp/RasterImage.php
@@ -34,7 +34,7 @@ interface RasterImage
     public function getRasterData(): string;
 
     /**
-     * Produce a new RasterImage based on this one. The new image will be scaled to the requested dimensions via resampling. 
+     * Produce a new RasterImage based on this one. The new image will be scaled to the requested dimensions via resampling.
      *
      * @param int $width The width of the returned image.
      * @param int $height The height of the returned image.

--- a/src/Mike42/ImagePhp/RgbRasterImage.php
+++ b/src/Mike42/ImagePhp/RgbRasterImage.php
@@ -34,7 +34,7 @@ class RgbRasterImage extends AbstractRasterImage
         return $this -> maxVal;
     }
 
-    public function getPixel(int $x, int $y)
+    public function getPixel(int $x, int $y) : int
     {
         if ($x < 0 || $x >= $this -> width) {
             return 0;


### PR DESCRIPTION
This update writes a lot more information from the generated Sphinx documentation.

Eg. Before-

![image](https://user-images.githubusercontent.com/2080552/39690021-ff14c06a-521b-11e8-8974-d5434fb633f8.png)

After-

![image](https://user-images.githubusercontent.com/2080552/39689995-ec0667da-521b-11e8-947e-9e181471c521.png)

Ref:

- #21
